### PR TITLE
Verify the full-text index at startup

### DIFF
--- a/deploy/bitcal-api.service
+++ b/deploy/bitcal-api.service
@@ -55,7 +55,7 @@ Type=simple
 User=bitcal
 Group=bitcal
 WorkingDirectory=/srv/bitcal
-ExecStart=/srv/bitcal/bin/bitcal-api
+ExecStart=/srv/bitcal/api/bitcal-api
 Restart=on-failure
 RestartSec=5s
 

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -411,19 +411,50 @@ Error responses will typically be in JSON format, like:
         "en": {
           "path": "/srv/bitcal/data/releases/20260809T084800Z/events_en.db",
           "sha256": "cb95ad42a181aff3f2cf0579ee3f0d647b81db38c8f3228e1d0483fd69a845f2",
-          "rows": 565
+          "rows": 565,
+          "fts": { "indexed": 565, "consistent": true }
         },
         "ru": {
           "path": "/srv/bitcal/data/releases/20260809T084800Z/events_ru.db",
           "sha256": "b2bf2c80054f20dd47d633144d62a5edc46e2184884756fa8719325e1b42581a",
-          "rows": 582
+          "rows": 582,
+          "fts": { "indexed": 582, "consistent": true }
         }
       }
     }
     ```
+
+#### Fields
+
+| Field | Meaning |
+| --- | --- |
+| `status` | `ok`, or `degraded` when some artifact's full-text index does not cover every row. |
+| `version` | Baked in at build time. `dev` means it was built without the Makefile. |
+| `path` | Symlink-resolved path of the file this process has open. |
+| `sha256` | Hash of that file, computed once at startup. |
+| `rows` | Rows in `events`. |
+| `fts.indexed` | Documents in the full-text index, read from `events_fts_docsize`. |
+| `fts.consistent` | `fts.indexed == rows` — every event is reachable by `/api/search`. |
+
+#### On the status code
+
+`/health` answers **200 whenever the service is serving**, including when `status` is
+`degraded`. A degraded process is answering every endpoint correctly except for the
+completeness of search, and returning a failure code would have a load balancer pull it for
+no good reason. **Read the `status` field, not the HTTP code.**
+
+The states that would make search useless rather than incomplete — the index missing, empty,
+or unreadable — are not reported here at all, because the service refuses to start on them.
+See *Startup checks* in [Deployment](Deployment.md).
+
 *   **Example:**
     ```bash
     curl "http://localhost:3000/health"
+
+    # In a release check — asserts the service is serving what you published,
+    # and that all of it is searchable.
+    curl -sf localhost:3000/health | jq -e '
+      .status == "ok" and (.databases | to_entries | all(.value.fts.consistent))'
     ```
 
 [![⚡️zapmeacoffee](https://img.shields.io/badge/⚡️zap_-me_a_coffee-violet?style=plastic)](https://zapmeacoffee.com/npub1tcalvjvswjh5rwhr3gywmfjzghthexjpddzvlxre9wxfqz4euqys0309hn) 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -38,7 +38,7 @@ Two things about this build are not optional:
 ## Installing
 
 ```sh
-sudo install -o root -g root -m 0755 bitcal-api /srv/bitcal/bin/bitcal-api
+sudo install -o root -g root -m 0755 bitcal-api /srv/bitcal/api/bitcal-api
 sudo cp deploy/bitcal-api.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now bitcal-api

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -72,6 +72,24 @@ hashes against the `SHA256SUMS` that shipped with the release.
 
 There is no publish script yet; the steps are manual.
 
+## Startup checks
+
+Before it listens, the service opens each artifact and proves its full-text index works. It
+refuses to start if the index is missing, empty, or unreadable.
+
+That looks heavy-handed for one endpoint, and it is deliberate. A broken FTS index does not
+produce an error — `/api/search` returns an empty result set, which is indistinguishable from
+a query that genuinely matched nothing. The Telegram bot would post nothing and report
+success. Every other endpoint would keep working. Nothing downstream can detect this, so
+startup is the only place where it can be made loud.
+
+An index that is merely *incomplete* is not fatal: the service starts, logs a warning naming
+the counts, and reports `"status": "degraded"` on `/health`. Partial search beats no service.
+
+```
+Full-text index does not cover every row: search will return incomplete results
+```
+
 ## Verifying a deployment
 
 ```sh
@@ -84,12 +102,27 @@ curl -s -H "X-API-KEY: $KEY" 'localhost:3000/api/search?q=bitcoin&lang=en' | jq 
 ```
 
 `/health` is the one that matters: it names the resolved release path and the SHA-256 of each
-file the process actually has open.
+file the process actually has open, and reports whether the whole corpus is searchable.
+
+As a single assertion for a release check:
+
+```sh
+curl -sf localhost:3000/health | jq -e '
+  .status == "ok" and (.databases | to_entries | all(.value.fts.consistent))'
+```
 
 ## Troubleshooting
 
-*   **`no such module: fts5`** — the binary was built without `-tags fts5`. Only `/api/search`
-    and anything else touching `events_fts` will fail; the rest of the API looks fine.
+*   **`no such module: fts5`** — the binary was built without `-tags fts5`. This should be
+    impossible: the build fails without the tag (`fts5_required.go`).
+*   **Exits naming `events_fts`** — the artifact's full-text index is missing, empty or
+    unreadable. The message says which. Do not work around it by removing the check: the
+    symptom in production is search silently returning nothing. Rebuild the artifact and
+    verify with `sqlite3 events_xx.db "INSERT INTO events_fts(events_fts) VALUES('integrity-check')"`
+    before publishing.
+*   **`"status": "degraded"`** — the index covers fewer rows than `events` holds; compare
+    `fts.indexed` against `rows` per language. Search works but misses events. The artifact
+    was published with a partly-built index.
 *   **Exits at startup naming `DB_PATH_EN` or `DB_PATH_RU`** — the variable is unset. There
     are deliberately no defaults.
 *   **`unable to open database file (14)`** — usually a WAL-mode artifact shipped without its

--- a/fts.go
+++ b/fts.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ftsProbeTimeout bounds the boot probe. A probe that hangs is a boot that
+// hangs, and the /api/tags incident showed that a query in this service can in
+// fact hang rather than fail.
+const ftsProbeTimeout = 10 * time.Second
+
+// ftsProbeTerm is a token deliberately chosen to match nothing in either
+// language. The probe cares that the query *executes*, not that it returns
+// rows: a term with hits would make the probe's cost scale with the corpus for
+// no extra assurance.
+const ftsProbeTerm = "zzqxnonexistenttoken"
+
+// FTSHealth reports the state of one artifact's full-text index.
+//
+// Indexed is read from events_fts_docsize, the shadow table holding one row per
+// indexed document. It is deliberately not `SELECT count(*) FROM events_fts`:
+// events_fts is an external-content table (content='events'), so a count
+// against it is answered by reading the *content* table and therefore always
+// equals Rows — it can never reveal a divergence, which is the one thing worth
+// measuring here.
+type FTSHealth struct {
+	Indexed int64 `json:"indexed"`
+	// Consistent is Indexed == Rows: every event is reachable by search.
+	// When false, search silently returns incomplete results — the failure
+	// this field exists to make visible.
+	Consistent bool `json:"consistent"`
+}
+
+// probeFTS verifies at startup that this artifact's full-text search actually
+// works, and returns what /health should report about it.
+//
+// The build tag guard (fts5_required.go) proves the *binary* can do FTS5. This
+// proves the *artifact* can. They are independent failures: a correctly built
+// binary opening a database whose FTS tables were dropped, or rebuilt without
+// the extension, serves an empty result for every search and logs nothing.
+// Search returning zero hits looks identical to a genuine absence of matches,
+// so nothing downstream would report it — the Telegram bot would simply go
+// quiet. Failing the boot is the only point at which this is loud.
+//
+// What it cannot check: whether the index contents actually correspond to the
+// current rows. FTS5's own integrity-check runs as an INSERT into the table,
+// which _query_only=1 correctly refuses. That check belongs to the publisher,
+// which runs it against the staged copy before the symlink flip.
+func probeFTS(db *gorm.DB, rows int64) (FTSHealth, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ftsProbeTimeout)
+	defer cancel()
+	db = db.WithContext(ctx)
+
+	// 1. The table exists and is FTS5. COALESCE keeps this to exactly one row
+	// whether or not the table is there, so an absent table is an empty string
+	// rather than a no-rows condition GORM would report as success.
+	var ddl string
+	if err := db.Raw(
+		`SELECT COALESCE((SELECT sql FROM sqlite_master WHERE type='table' AND name='events_fts'), '')`,
+	).Scan(&ddl).Error; err != nil {
+		return FTSHealth{}, fmt.Errorf("reading events_fts definition: %w", err)
+	}
+	if ddl == "" {
+		return FTSHealth{}, fmt.Errorf("events_fts is missing: this artifact cannot serve /api/search")
+	}
+	if !strings.Contains(strings.ToLower(ddl), "fts5") {
+		return FTSHealth{}, fmt.Errorf("events_fts is not an FTS5 table: %s", ddl)
+	}
+
+	// 2. The production query shape runs. This is the search handler's own
+	// count statement, so it exercises the join between events.id and the
+	// index's rowid rather than merely touching the index — a content_rowid
+	// mismatch would pass a bare MATCH and return nothing here.
+	var probe int64
+	if err := db.Raw(
+		`SELECT count(*) FROM events e JOIN events_fts fts ON e.id = fts.rowid WHERE events_fts MATCH ?`,
+		ftsProbeTerm,
+	).Scan(&probe).Error; err != nil {
+		return FTSHealth{}, fmt.Errorf("events_fts is not queryable: %w", err)
+	}
+
+	// 3. How much is actually indexed.
+	var indexed int64
+	if err := db.Raw(`SELECT count(*) FROM events_fts_docsize`).Scan(&indexed).Error; err != nil {
+		return FTSHealth{}, fmt.Errorf(
+			"reading events_fts_docsize: %w (an FTS5 table built with columnsize=0 has no such "+
+				"shadow table; this service's artifacts are not built that way)", err)
+	}
+	if indexed == 0 && rows > 0 {
+		return FTSHealth{}, fmt.Errorf(
+			"events_fts is empty while events holds %d rows: every search would return nothing", rows)
+	}
+
+	return FTSHealth{Indexed: indexed, Consistent: indexed == rows}, nil
+}

--- a/health.go
+++ b/health.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,18 +18,30 @@ var version = "dev"
 
 // DatabaseHealth describes one artifact as this process actually has it open.
 type DatabaseHealth struct {
-	Path   string `json:"path"`
-	SHA256 string `json:"sha256"`
-	Rows   int64  `json:"rows"`
+	Path   string    `json:"path"`
+	SHA256 string    `json:"sha256"`
+	Rows   int64     `json:"rows"`
+	FTS    FTSHealth `json:"fts"`
 }
 
 // HealthResponse is a cross-repo contract: the publisher asserts against it
 // after every release.
+//
+// Status is "ok", or "degraded" when an artifact opened successfully but its
+// full-text index does not cover every row. The endpoint answers 200 either
+// way: a degraded service is still serving, and returning a failure code would
+// have a load balancer pull a process that is answering correctly for
+// everything except the completeness of search. Read the field, not the code.
 type HealthResponse struct {
 	Status    string                    `json:"status"`
 	Version   string                    `json:"version"`
 	Databases map[string]DatabaseHealth `json:"databases"`
 }
+
+const (
+	statusOK       = "ok"
+	statusDegraded = "degraded"
+)
 
 // healthSnapshot is computed once at startup and served unchanged thereafter.
 var healthSnapshot HealthResponse
@@ -43,7 +56,7 @@ func buildHealthSnapshot(dbs map[string]struct {
 	DB   *gorm.DB
 }) (HealthResponse, error) {
 	snapshot := HealthResponse{
-		Status:    "ok",
+		Status:    statusOK,
 		Version:   version,
 		Databases: make(map[string]DatabaseHealth, len(dbs)),
 	}
@@ -66,10 +79,21 @@ func buildHealthSnapshot(dbs map[string]struct {
 			return HealthResponse{}, err
 		}
 
+		// A failure here aborts the boot: probeFTS only errors on conditions
+		// under which search cannot work at all.
+		fts, err := probeFTS(entry.DB, rows)
+		if err != nil {
+			return HealthResponse{}, fmt.Errorf("%s: %w", lang, err)
+		}
+		if !fts.Consistent {
+			snapshot.Status = statusDegraded
+		}
+
 		snapshot.Databases[lang] = DatabaseHealth{
 			Path:   resolved,
 			SHA256: sum,
 			Rows:   rows,
+			FTS:    fts,
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -500,7 +500,24 @@ func main() {
 		zlog.Fatal().Err(err).Msg("Failed to build health snapshot")
 	}
 	for lang, info := range healthSnapshot.Databases {
-		zlog.Info().Str("lang", lang).Str("path", info.Path).Str("sha256", info.SHA256).Int64("rows", info.Rows).Msg("Artifact opened")
+		zlog.Info().
+			Str("lang", lang).
+			Str("path", info.Path).
+			Str("sha256", info.SHA256).
+			Int64("rows", info.Rows).
+			Int64("fts_indexed", info.FTS.Indexed).
+			Msg("Artifact opened")
+
+		// Not fatal: the service answers every other endpoint correctly, and
+		// taking it down would trade partial search for none at all. It is
+		// logged at warn and reported by /health so a release check catches it.
+		if !info.FTS.Consistent {
+			zlog.Warn().
+				Str("lang", lang).
+				Int64("rows", info.Rows).
+				Int64("fts_indexed", info.FTS.Indexed).
+				Msg("Full-text index does not cover every row: search will return incomplete results")
+		}
 	}
 
 	// --- Fiber App Initialization ---

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -14,15 +14,7 @@ import (
 // directory. Anything issuing DDL or negotiating WAL at startup dies here.
 // TestMain has already proved the boot; this checks it is actually serving.
 func TestServesReadOnlyArtifact(t *testing.T) {
-	var health struct {
-		Status    string `json:"status"`
-		Version   string `json:"version"`
-		Databases map[string]struct {
-			Path   string `json:"path"`
-			SHA256 string `json:"sha256"`
-			Rows   int64  `json:"rows"`
-		} `json:"databases"`
-	}
+	var health healthDoc
 	if code := request(t, http.MethodGet, "/health", false, &health); code != http.StatusOK {
 		t.Fatalf("/health: want 200 without an API key, got %d", code)
 	}
@@ -41,6 +33,15 @@ func TestServesReadOnlyArtifact(t *testing.T) {
 		}
 		if db.Rows == 0 {
 			t.Errorf("%s: reports 0 rows", lang)
+		}
+		// The release check reads these: they are what turns "the service is
+		// up" into "the service is serving the artifact I just published, and
+		// all of it is searchable".
+		if db.FTS.Indexed != db.Rows {
+			t.Errorf("%s fts.indexed: want %d to match rows, got %d", lang, db.Rows, db.FTS.Indexed)
+		}
+		if !db.FTS.Consistent {
+			t.Errorf("%s fts.consistent: want true", lang)
 		}
 	}
 	if health.Databases["ru"].Rows != 4 || health.Databases["en"].Rows != 3 {

--- a/tests/boot_test.go
+++ b/tests/boot_test.go
@@ -1,0 +1,318 @@
+package tests
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// healthDoc mirrors /health. It is spelled out here rather than imported from
+// the service because that is the point of a black-box test: if the JSON the
+// publisher reads changes shape, this fails to unmarshal.
+type healthDoc struct {
+	Status    string `json:"status"`
+	Version   string `json:"version"`
+	Databases map[string]struct {
+		Path   string `json:"path"`
+		SHA256 string `json:"sha256"`
+		Rows   int64  `json:"rows"`
+		FTS    struct {
+			Indexed    int64 `json:"indexed"`
+			Consistent bool  `json:"consistent"`
+		} `json:"fts"`
+	} `json:"databases"`
+}
+
+// stageArtifact builds a fresh pair of databases in their own directory, runs
+// the given mutation against each, and stages them exactly as a release does:
+// mode 0444 in a 0555 directory. A nil mutation leaves a healthy artifact.
+func stageArtifact(t *testing.T, mutate func(*sql.DB) error) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "artifact")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("creating artifact dir: %v", err)
+	}
+	// Registered after TempDir's own cleanup and therefore run before it:
+	// the directory must be writable again for the temp dir to be removed.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	for _, lang := range []string{"en", "ru"} {
+		path := filepath.Join(dir, "events_"+lang+".db")
+		if err := seedArtifact(path, lang); err != nil {
+			t.Fatalf("seeding %s: %v", lang, err)
+		}
+		if mutate != nil {
+			db, err := sql.Open("sqlite3", path)
+			if err != nil {
+				t.Fatalf("opening %s: %v", lang, err)
+			}
+			err = mutate(db)
+			db.Close()
+			if err != nil {
+				t.Fatalf("mutating %s: %v", lang, err)
+			}
+		}
+		if err := os.Chmod(path, 0o444); err != nil {
+			t.Fatalf("chmod %s: %v", lang, err)
+		}
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	return dir
+}
+
+// bootService starts a second instance of the real binary against the given
+// artifact directory. It returns the base URL, the service's log, and the
+// startup error if it never became healthy. The process is killed on cleanup
+// whichever of those happened.
+func bootService(t *testing.T, dir string) (base, serviceLog string, startErr error) {
+	t.Helper()
+
+	port, err := freePort()
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	base = fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	logPath := filepath.Join(t.TempDir(), "server.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("creating log: %v", err)
+	}
+	defer logFile.Close()
+
+	srv := exec.Command(binaryPath)
+	srv.Env = append(os.Environ(),
+		fmt.Sprintf("LISTEN_ADDR=127.0.0.1:%d", port),
+		"DB_PATH_EN="+filepath.Join(dir, "events_en.db"),
+		"DB_PATH_RU="+filepath.Join(dir, "events_ru.db"),
+		"API_KEYS="+apiKey,
+	)
+	srv.Stdout, srv.Stderr = logFile, logFile
+	if err := srv.Start(); err != nil {
+		t.Fatalf("starting the service: %v", err)
+	}
+
+	var exitErr error
+	exited := make(chan struct{})
+	go func() { exitErr = srv.Wait(); close(exited) }()
+	t.Cleanup(func() {
+		_ = srv.Process.Kill()
+		<-exited
+	})
+
+	// Short: every outcome under test is decided within a second or two of
+	// opening the databases, and a wrong answer here should not cost 30s.
+	startErr = waitForHealth(base, exited, &exitErr, 15*time.Second)
+	out, _ := os.ReadFile(logPath)
+	return base, string(out), startErr
+}
+
+// TestBootProbeRejectsUnusableFTS is the reason the probe exists. Each mutation
+// here leaves a database that opens perfectly and answers every endpoint except
+// search — and search answers too, with an empty result that is indistinguishable
+// from "no matches". Nothing downstream can tell the difference: the Telegram
+// bot would simply post nothing and report no error. Refusing to boot is the
+// only moment at which any of this is loud.
+func TestBootProbeRejectsUnusableFTS(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*sql.DB) error
+		expect string // must appear in the service's log
+	}{
+		{
+			// An artifact rebuilt by a tool without the FTS5 extension, or one
+			// where the index was dropped to save space.
+			name: "index missing",
+			mutate: func(db *sql.DB) error {
+				for _, s := range []string{
+					`DROP TRIGGER events_ai`, `DROP TRIGGER events_ad`,
+					`DROP TRIGGER events_au`, `DROP TABLE events_fts`,
+				} {
+					if _, err := db.Exec(s); err != nil {
+						return fmt.Errorf("%s: %w", s, err)
+					}
+				}
+				return nil
+			},
+			expect: "events_fts is missing",
+		},
+		{
+			// The table is present and queryable; it just holds nothing. This
+			// is the case a "does events_fts exist?" check would pass.
+			name: "index empty",
+			mutate: func(db *sql.DB) error {
+				_, err := db.Exec(`INSERT INTO events_fts(events_fts) VALUES('delete-all')`)
+				return err
+			},
+			expect: "events_fts is empty",
+		},
+		{
+			// Index data lost while its metadata survived — a truncated copy,
+			// a bad transfer, bit rot. This is the case that only the MATCH
+			// probe catches: the table is present and events_fts_docsize still
+			// reports a document per row, so both of the other two checks pass
+			// and the artifact looks entirely healthy until something searches.
+			name: "index data corrupt",
+			mutate: func(db *sql.DB) error {
+				_, err := db.Exec(`DELETE FROM events_fts_data`)
+				return err
+			},
+			expect: "events_fts is not queryable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := stageArtifact(t, tc.mutate)
+			_, serviceLog, startErr := bootService(t, dir)
+
+			if startErr == nil {
+				t.Fatalf("the service booted against an artifact whose FTS index is unusable "+
+					"(%s); every /api/search would return an empty result and nothing would "+
+					"report it", tc.name)
+			}
+			if !strings.Contains(serviceLog, tc.expect) {
+				t.Errorf("the service refused to boot, but its log does not say why.\n"+
+					"want it to contain %q\n--- log ---\n%s", tc.expect, serviceLog)
+			}
+		})
+	}
+}
+
+// TestBootProbeAcceptsHealthyArtifact is the control. Without it the test above
+// passes just as well against a probe that rejects everything.
+func TestBootProbeAcceptsHealthyArtifact(t *testing.T) {
+	dir := stageArtifact(t, nil)
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("the service refused an artifact that is not broken: %v\n--- log ---\n%s",
+			startErr, serviceLog)
+	}
+
+	var health healthDoc
+	fetchJSON(t, base+"/health", &health)
+	if health.Status != "ok" {
+		t.Errorf("status: want ok, got %q", health.Status)
+	}
+	for lang, db := range health.Databases {
+		if !db.FTS.Consistent || db.FTS.Indexed != db.Rows {
+			t.Errorf("%s: healthy artifact reported as inconsistent (rows=%d indexed=%d consistent=%v)",
+				lang, db.Rows, db.FTS.Indexed, db.FTS.Consistent)
+		}
+	}
+}
+
+// TestPartialIndexIsReportedNotFatal covers the middle case, which is the one
+// the release check is actually for. A partly-built index is not grounds to
+// take the service down — everything except the completeness of search still
+// works — so it must boot, say so in the log, and mark itself degraded.
+func TestPartialIndexIsReportedNotFatal(t *testing.T) {
+	// Drop exactly one row from each index, leaving the row itself in place.
+	dir := stageArtifact(t, func(db *sql.DB) error {
+		var id int
+		var title, description, tags string
+		err := db.QueryRow(
+			`SELECT id, title, description, tags FROM events ORDER BY id LIMIT 1`,
+		).Scan(&id, &title, &description, &tags)
+		if err != nil {
+			return err
+		}
+		_, err = db.Exec(
+			`INSERT INTO events_fts(events_fts, rowid, title, description, tags) VALUES('delete',?,?,?,?)`,
+			id, title, description, tags)
+		return err
+	})
+
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("a partial index took the service down; it should degrade, not die: %v\n"+
+			"--- log ---\n%s", startErr, serviceLog)
+	}
+
+	var health healthDoc
+	fetchJSON(t, base+"/health", &health)
+
+	if health.Status != "degraded" {
+		t.Errorf("status: want degraded with an incomplete index, got %q", health.Status)
+	}
+	for lang, db := range health.Databases {
+		if db.FTS.Consistent {
+			t.Errorf("%s: reports a consistent index after one document was removed from it", lang)
+		}
+		if db.FTS.Indexed != db.Rows-1 {
+			t.Errorf("%s: indexed=%d, want %d (rows=%d, one removed)",
+				lang, db.FTS.Indexed, db.Rows-1, db.Rows)
+		}
+	}
+	if !strings.Contains(serviceLog, "does not cover every row") {
+		t.Errorf("nothing in the log warns about the incomplete index:\n%s", serviceLog)
+	}
+}
+
+// TestIndexedIsNotReadFromTheVirtualTable pins the reason `indexed` comes from
+// events_fts_docsize. events_fts is an external-content table, so a count
+// against it is answered by reading events — it returns the row count no matter
+// what state the index is in, and would report a wholly empty index as
+// perfectly consistent.
+func TestIndexedIsNotReadFromTheVirtualTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "probe.db")
+	if err := seedArtifact(path, "en"); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`INSERT INTO events_fts(events_fts) VALUES('delete-all')`); err != nil {
+		t.Fatalf("emptying the index: %v", err)
+	}
+
+	var rows, viaVirtualTable, viaDocsize int64
+	for q, dst := range map[string]*int64{
+		`SELECT count(*) FROM events`:             &rows,
+		`SELECT count(*) FROM events_fts`:         &viaVirtualTable,
+		`SELECT count(*) FROM events_fts_docsize`: &viaDocsize,
+	} {
+		if err := db.QueryRow(q).Scan(dst); err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+	}
+
+	if viaDocsize != 0 {
+		t.Errorf("docsize reports %d documents in an emptied index", viaDocsize)
+	}
+	if viaVirtualTable != rows {
+		t.Logf("count(*) on the external-content table returned %d for %d rows; it no "+
+			"longer reads through to the content table. The docsize source stays "+
+			"correct either way.", viaVirtualTable, rows)
+	}
+}
+
+func fetchJSON(t *testing.T, url string, into interface{}) {
+	t.Helper()
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: %d", url, res.StatusCode)
+	}
+	if err := json.NewDecoder(res.Body).Decode(into); err != nil {
+		t.Fatalf("decoding %s: %v", url, err)
+	}
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -27,6 +27,7 @@ var (
 	baseURL     string
 	artifactDir string
 	fixtureSums map[string]string // filename -> sha256 at publish time
+	binaryPath  string            // built once by run(); reused to boot extra instances
 )
 
 // TestMain stages an artifact the way a release does, starts the real binary
@@ -53,6 +54,7 @@ func run(m *testing.M) (int, error) {
 	}()
 
 	binary := filepath.Join(workDir, "bitcal-api")
+	binaryPath = binary
 	build := exec.Command("go", "build", "-tags", "fts5", "-o", binary, ".")
 	build.Dir = ".."
 	build.Env = append(os.Environ(), "CGO_ENABLED=1")
@@ -123,7 +125,7 @@ func run(m *testing.M) (int, error) {
 		<-exited
 	}()
 
-	if err := waitForHealth(exited, &exitErr, 30*time.Second); err != nil {
+	if err := waitForHealth(baseURL, exited, &exitErr, 30*time.Second); err != nil {
 		out, _ := os.ReadFile(filepath.Join(workDir, "server.log"))
 		return 0, fmt.Errorf("%w\n--- server log ---\n%s", err, out)
 	}
@@ -268,7 +270,7 @@ func freePort() (int, error) {
 // waitForHealth blocks until the service answers /health, and distinguishes the
 // three ways that can fail. Each has a different cause and a different fix, so
 // collapsing them into one timeout message wastes the reader's time.
-func waitForHealth(exited <-chan struct{}, exitErr *error, within time.Duration) error {
+func waitForHealth(base string, exited <-chan struct{}, exitErr *error, within time.Duration) error {
 	deadline := time.Now().Add(within)
 	var last error
 
@@ -280,7 +282,7 @@ func waitForHealth(exited <-chan struct{}, exitErr *error, within time.Duration)
 		default:
 		}
 
-		res, err := http.Get(baseURL + "/health")
+		res, err := http.Get(base + "/health")
 		if err == nil {
 			res.Body.Close()
 			switch res.StatusCode {


### PR DESCRIPTION
## Why

The FTS5 build tag guard proves the *binary* can do full-text search. Nothing proved the *artifact* could.

Those fail independently, and the artifact side fails silently: an index that is missing, empty or corrupt makes `/api/search` return an empty result set, which is indistinguishable from a query that genuinely matched nothing. Every other endpoint keeps working. The Telegram bot would post nothing and report success. Nothing downstream can detect it — startup is the only place it can be made loud.

## What

**Boot probe** (`fts.go`), three checks, each independently load-bearing:

1. `events_fts` exists and is FTS5 — catches an artifact rebuilt without the extension.
2. The search handler's own count query runs — catches corrupt index data whose metadata survived.
3. `events_fts_docsize` is non-empty — catches an index that is present but holds nothing.

Any of these failing aborts the boot with a message naming the cause.

**`/health` gains `fts.indexed` and `fts.consistent`.** `indexed` comes from `events_fts_docsize`, deliberately not `count(*) FROM events_fts`: `events_fts` is an external-content table, so a count against it is answered by reading `events` and always equals `rows` — it can never reveal a divergence.

An index that is merely *incomplete* is not fatal. The service starts, logs a warning, and reports `"status": "degraded"`. Partial search beats no service. `/health` still answers 200 — read the field, not the code.

Release check is now one assertion:

```sh
curl -sf localhost:3000/health | jq -e '.status == "ok" and (.databases | to_entries | all(.value.fts.consistent))'
```

## Tests

Four new tests boot a second instance of the real binary against deliberately broken artifacts. Each failure mode was verified to be caught by exactly the check intended for it, by mutation:

| mutation | fails |
| --- | --- |
| probe replaced with a stub | index missing, index empty, index data corrupt, partial |
| `docsize` → `count(*) FROM events_fts` | index empty, partial |
| MATCH probe removed | index data corrupt only |

## Verified on the box

Built on the target (Ubuntu 24.04, glibc 2.39), full suite green there. Release `20260809T092607Z` staged and serving: `/health` hashes match the shipped `SHA256SUMS` line for line, en 565/565 and ru 582/582 indexed, search returns 450 en / 246 ru, artifacts byte-identical after serving traffic with no sidecars created.