### PR TITLE
Expose category, and gate releases on the API being able to emit the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ These are the parts that are not guessable from the endpoint list. Each was a re
     timestamp. Rendering those as `"0001-01-01T00:00:00Z"` would be inventing data.
 *   **`url_path`** (`/2013-08-09/hal-finneys-last-post/`) is the cross-language join key and
     the website's page URL. It is present on every row.
+*   **`category` is not `tags[0]`.** Every event has exactly one `category`, from a closed list
+    of 14, and it is what the website colours and filters by. Consumers used to derive it from
+    the first tag; tag order carries no meaning now and that inference is wrong. `bitcoin` is
+    the sharp edge: it is a category on 148 RU and 82 EN events and **no longer a tag on any**,
+    so `/api/events/tags/bitcoin` returns an empty list. There is no `?category=` filter yet —
+    fetch and filter client-side, or ask for one.
 *   **`events` is always an array**, `[]` when nothing matches, on every endpoint that
     returns a list.
 *   **An unknown `lang` silently serves English.** `lang=xx` is not an error. Do not rely on
@@ -131,10 +137,18 @@ it. Startup is the only place it can be made loud.
 A native systemd service, not Docker. The unit is `deploy/bitcal-api.service`; it binds
 loopback only and is not proxied by nginx.
 
-Database releases are published with `deploy/publish-db.sh`, which validates the source,
-stages it, validates the staged copy again, flips the `current` symlink, restarts the service
-— mandatory, since SQLite holds an open file descriptor and the symlink alone changes nothing
-— then verifies `/health` and rolls back automatically if any of that fails.
+There are two release paths and they do not overlap:
+
+*   **`deploy/publish-db.sh`** ships database artifacts. It validates the source, stages it,
+    validates the staged copy again, checks that this API can actually emit the staged
+    schema, flips the `current` symlink, restarts the service — mandatory, since SQLite holds
+    an open file descriptor and the symlink alone changes nothing — then verifies `/health`.
+*   **`deploy/publish-api.sh`** ships the binary. It builds on the box (CGO ties the binary to
+    the target's glibc), runs the suite there, backs the running binary aside, installs,
+    restarts, and asserts `/health` shows a new version **and unchanged data**.
+
+Both roll back automatically if anything after the irreversible step fails. Because they are
+independent, the binary and the data drift; check both halves of `/health` when diagnosing.
 
 See [docs/Deployment.md](docs/Deployment.md).
 

--- a/database.go
+++ b/database.go
@@ -54,7 +54,11 @@ func (d DateString) Value() (driver.Value, error) { return string(d), nil }
 // Event matches the schema of the canonical database artifact:
 //
 //	events(id, date, title, description, media, tags, "references",
-//	       created_at, updated_at, url_path)
+//	       created_at, updated_at, url_path, category)
+//
+// The column order above is RU's. EN declares the same names in a different
+// order — media is fourth in RU and eighth in EN — so nothing here or in the
+// tests may be positional; match on names.
 //
 // Date is TEXT in YYYY-MM-DD form and the range starts at 1881-09-29 — before
 // the Unix epoch. It is a string here so the API emits "1881-09-29" rather than
@@ -66,6 +70,20 @@ func (d DateString) Value() (driver.Value, error) { return string(d), nil }
 //
 // URLPath is /<date>/<slug>/, the cross-language join key and the website's
 // page URL. The Telegram bot already reads it.
+//
+// Category is the single mandatory classification, one value per row from a
+// closed list of 14, and it is what the website colours and filters by. It is a
+// plain string rather than a pointer on purpose: absence is a validator failure
+// upstream, not a state this API should be able to represent. Note that the
+// closed list is enforced by validate.py invariant 13 and not by the DDL — the
+// column is declared TEXT with notnull=0 — so the data is clean because the
+// publisher checks it, not because the database would refuse otherwise.
+// Measured 2026-08-10 across both artifacts: 0 NULL, 0 empty, 0 values outside
+// the 14, in 1,146 rows.
+//
+// Consumers used to derive this from tags[0]. That inference is now wrong: tag
+// order carries no meaning, and `bitcoin` is a category value with no
+// corresponding tag left in the data at all.
 //
 // CreatedAt and UpdatedAt are pointers for the same reason as Media: they are
 // genuinely absent on many rows (505 of 582 RU created_at, 265 of 565 EN), and
@@ -82,6 +100,7 @@ type Event struct {
 	Media       *string    `json:"media" gorm:"type:text"`      // JSON array as string, e.g. ["url1","url2"]; NULL when absent
 	References  *string    `json:"references" gorm:"type:text"` // JSON array as string; NULL when absent
 	URLPath     string     `json:"url_path" gorm:"column:url_path"`
+	Category    string     `json:"category" gorm:"column:category"`
 	CreatedAt   *time.Time `json:"created_at"` // NULL on many rows; renders as null
 	UpdatedAt   *time.Time `json:"updated_at"` // NULL on many rows; renders as null
 }

--- a/deploy/bitcal-api.service
+++ b/deploy/bitcal-api.service
@@ -5,6 +5,64 @@
 #   sudo systemctl daemon-reload && sudo systemctl enable --now bitcal-api
 #
 # ---------------------------------------------------------------------------
+# Two release paths, deliberately separate
+# ---------------------------------------------------------------------------
+#
+#   deploy/publish-db.sh    ships database artifacts. Never rebuilds anything.
+#   deploy/publish-api.sh   ships the binary. Never touches the data.
+#
+# They are independent, which means they drift: on 2026-08-09 the box served
+# freshly published artifacts for about 35 minutes while still running the
+# previous binary. That is allowed and usually fine — but when you are
+# diagnosing something, check both. /health reports the binary's version and
+# the artifact's sha256 side by side for exactly that reason.
+#
+# ---------------------------------------------------------------------------
+# Releasing the binary
+# ---------------------------------------------------------------------------
+#
+# Use deploy/publish-api.sh. The steps it automates, for when you have to do it
+# by hand:
+#
+#   1. Export the committed tree to the box and build it THERE. CGO ties the
+#      binary to the C library it was built against; this box is glibc 2.39 and
+#      a binary built on a Mac will not start at all:
+#
+#        D=$(ssh root@host "mktemp -d /tmp/bitcal-build.XXXXXX")
+#        git archive --format=tar HEAD | ssh root@host "tar -x -C $D"
+#        ssh root@host "cd $D && PATH=/usr/local/go/bin:\$PATH \
+#                       make build VERSION=0.1.0-\$(git rev-parse --short HEAD)"
+#
+#      Pass VERSION explicitly. The exported tree has no .git, so the
+#      Makefile's `git rev-parse` fallback yields 0.1.0-unknown — and you find
+#      out from /health afterwards. Go is at /usr/local/go/bin and is not on
+#      root's PATH.
+#
+#   2. Run `make test` in that directory, on the box. The suite is black-box —
+#      it builds the binary, stages a fixture at 0444 in a 0555 directory and
+#      drives it over HTTP — so it proves the fts5 build tag, the read-only
+#      open and the boot probe against this machine's own libc. ~8s.
+#
+#   3. Back up the running binary, then RENAME the new one over it. Writing
+#      over a busy executable in place fails with ETXTBSY; a rename swaps the
+#      directory entry and leaves the running process on its old inode:
+#
+#        sudo cp -p /srv/bitcal/api/bitcal-api \
+#                   /srv/bitcal/api/bitcal-api.bak-$(date -u +%Y%m%dT%H%M%SZ)
+#        sudo cp $D/bitcal-api /srv/bitcal/api/bitcal-api.new
+#        sudo chown root:root /srv/bitcal/api/bitcal-api.new
+#        sudo chmod 0755 /srv/bitcal/api/bitcal-api.new
+#        sudo mv -f /srv/bitcal/api/bitcal-api.new /srv/bitcal/api/bitcal-api
+#        sudo systemctl restart bitcal-api
+#
+#   4. Verify /health reports the new `version` AND the same database sha256s
+#      and row counts as before. A binary deploy must not move the data — if
+#      those hashes changed, something else restarted into a different release
+#      and the two paths above have collided.
+#
+#      Roll back by copying the .bak-<timestamp> back over and restarting.
+#
+# ---------------------------------------------------------------------------
 # Releasing a database artifact
 # ---------------------------------------------------------------------------
 #

--- a/deploy/publish-api.sh
+++ b/deploy/publish-api.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+#
+# publish-api.sh — ship the bitcal-api binary to the box.
+#
+# The counterpart to publish-db.sh, and deliberately its mirror image: that
+# script ships data and never rebuilds anything, this one ships a binary and
+# never touches the data. Between them they are the only two ways the box
+# changes, and keeping them separate is what makes each one reviewable.
+#
+#   local  preflight  clean tree, HEAD pushed, make test, version string
+#   remote preflight  toolchain, and a /health snapshot to roll back to
+#   remote build      git archive HEAD -> temp dir on the box, build, make test
+#   remote install    back up the running binary, then rename the new one over it
+#   remote restart    systemctl restart (mandatory — the binary is running)
+#   remote verify     /health: the version moved and the DATA DID NOT
+#   remote prune      keep the last N .bak binaries
+#
+# Any failure after the install rolls back to the previous binary automatically.
+#
+# This is a transcription, not an invention. The procedure below was walked by
+# hand twice on 2026-08-09 — bitcal-api.bak-20260809T160545Z and the binary that
+# replaced it are both still on the box — and the steps are in this order
+# because that is the order that worked.
+#
+# Why the build happens ON THE BOX
+# --------------------------------
+# mattn/go-sqlite3 needs CGO, and CGO ties the binary to the C library it was
+# built against. The box is Ubuntu 24.04 / glibc 2.39; a binary built on this
+# Mac will not start there at all, and one built on Alpine (musl) will not
+# either. Building on the target makes the match true by construction rather
+# than by a Makefile target someone has to remember to use. `make build-ubuntu`
+# does the same job in Docker and is the documented alternative, but it needs a
+# Docker daemon running locally, which is one more thing to be wrong on the day
+# something is urgent. Go 1.23.12 and gcc are already installed on the box —
+# they were installed 92 seconds before the first release was built there.
+#
+# The source is exported with `git archive` into a temp directory and removed
+# afterwards, so no source tree and no build output persist on a production
+# host. That also means the tree that gets built is exactly what is committed:
+# an rsync of the working directory would quietly ship uncommitted edits under
+# a version string naming a commit that does not contain them.
+#
+# Why VERSION is passed explicitly
+# --------------------------------
+# The Makefile derives VERSION from `git rev-parse --short HEAD`. The exported
+# tree has no .git, so on the box that fallback yields `0.1.0-unknown` — and
+# /health reporting `unknown` is how you find out afterwards. It is passed on
+# the command line here for that reason; do not "simplify" it away.
+#
+# Usage:
+#   ./publish-api.sh                   # build, install, verify, with a prompt
+#   ./publish-api.sh --dry-run         # every local and remote check, no install
+#   ./publish-api.sh --yes             # no prompt
+#   ./publish-api.sh --keep 5          # how many .bak binaries to retain
+#   ./publish-api.sh --version 0.2.0   # override the derived version string
+#   ./publish-api.sh --allow-dirty     # build a tree git cannot account for
+#   ./publish-api.sh --host root@example
+#
+set -euo pipefail
+
+# --- defaults ---------------------------------------------------------------
+
+SSH_HOST="${BITCAL_HOST:-root@169.58.80.219}"
+REMOTE_API="/srv/bitcal/api"
+BINARY="bitcal-api"
+SERVICE="bitcal-api"
+HEALTH_URL="http://127.0.0.1:3000/health"
+# Not on root's PATH: the toolchain is installed under /usr/local/go and a bare
+# `which go` on the box finds nothing.
+REMOTE_GO="/usr/local/go/bin"
+KEEP=5
+DRY_RUN=0
+ASSUME_YES=0
+ALLOW_DIRTY=0
+VERSION=""
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# --- argument parsing -------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--host) SSH_HOST="$2"; shift 2 ;;
+	--keep) KEEP="$2"; shift 2 ;;
+	--version) VERSION="$2"; shift 2 ;;
+	--dry-run) DRY_RUN=1; shift ;;
+	--yes | -y) ASSUME_YES=1; shift ;;
+	--allow-dirty) ALLOW_DIRTY=1; shift ;;
+	-h | --help) sed -n '2,58p' "$0"; exit 0 ;;
+	*) echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
+	esac
+done
+
+case "$KEEP" in
+'' | *[!0-9]*) echo "--keep needs a number, got: $KEEP" >&2; exit 2 ;;
+esac
+[ "$KEEP" -ge 1 ] || { echo "--keep must be at least 1" >&2; exit 2; }
+
+# --- output helpers ---------------------------------------------------------
+
+if [ -t 1 ]; then
+	BOLD=$(printf '\033[1m'); RED=$(printf '\033[31m')
+	GREEN=$(printf '\033[32m'); YELLOW=$(printf '\033[33m'); OFF=$(printf '\033[0m')
+else
+	BOLD=""; RED=""; GREEN=""; YELLOW=""; OFF=""
+fi
+
+step() { printf '\n%s==> %s%s\n' "$BOLD" "$*" "$OFF"; }
+ok()   { printf '    %sok%s   %s\n' "$GREEN" "$OFF" "$*"; }
+warn() { printf '    %swarn%s %s\n' "$YELLOW" "$OFF" "$*"; }
+die()  { printf '\n%serror%s %s\n' "$RED" "$OFF" "$*" >&2; exit 1; }
+
+# One SSH connection, reused — same reason as publish-db.sh: without
+# multiplexing the health poll pays a full handshake per attempt.
+SSH_CTL_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bitcal-api-ssh.XXXXXX")
+SSH_OPTS=(-o BatchMode=yes -o ControlMaster=auto -o ControlPath="$SSH_CTL_DIR/ctl" -o ControlPersist=180)
+
+remote() { ssh "${SSH_OPTS[@]}" "$SSH_HOST" "$@"; }
+
+REMOTE_BUILD=""
+close_ssh() {
+	if [ -n "$REMOTE_BUILD" ]; then
+		remote "rm -rf '$REMOTE_BUILD'" >/dev/null 2>&1 || true
+	fi
+	ssh "${SSH_OPTS[@]}" -O exit "$SSH_HOST" >/dev/null 2>&1 || true
+	rm -rf "$SSH_CTL_DIR"
+}
+trap close_ssh EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Local preflight
+# ---------------------------------------------------------------------------
+
+step "Local preflight"
+
+cd "$REPO_ROOT"
+git rev-parse --git-dir >/dev/null 2>&1 || die "$REPO_ROOT is not a git repository"
+
+# Unlike publish-db.sh, this check is not scoped to a subdirectory: this repo is
+# the artifact. Anything uncommitted is something the built binary will not
+# contain, under a version string that names a commit which does not contain it
+# either.
+DIRTY=$(git status --porcelain)
+HEAD_SHA=$(git rev-parse --short HEAD)
+
+if [ -n "$DIRTY" ]; then
+	if [ "$ALLOW_DIRTY" -eq 1 ]; then
+		warn "the working tree is dirty and --allow-dirty was given:"
+		printf '%s\n' "$DIRTY" | sed 's/^/         /'
+		warn "the build exports HEAD, so these changes will NOT be in the binary"
+	else
+		printf '%s\n' "$DIRTY" | sed 's/^/       /'
+		die "the working tree is dirty.
+       The build exports HEAD with git archive, so these changes would not be in
+       the binary — but /health would report a version string naming this commit
+       as though they were. Commit them, or re-run with --allow-dirty."
+	fi
+fi
+
+# The version string is only useful if it identifies something another person
+# can check out. A binary built from an unpushed commit is one force-push away
+# from being unreproducible.
+if git rev-parse --verify origin/main >/dev/null 2>&1; then
+	if git merge-base --is-ancestor HEAD origin/main; then
+		ok "HEAD $HEAD_SHA is on origin/main"
+	elif [ "$ALLOW_DIRTY" -eq 1 ]; then
+		warn "HEAD $HEAD_SHA is not on origin/main; the version string will name a commit nobody else has"
+	else
+		die "HEAD ($HEAD_SHA) is not an ancestor of origin/main.
+       The binary would report a version string for a commit that exists only on
+       this machine. Push it first, or re-run with --allow-dirty."
+	fi
+else
+	warn "no origin/main to compare against; cannot confirm the commit is pushed"
+fi
+
+[ -n "$VERSION" ] || VERSION="0.1.0-$HEAD_SHA"
+ok "version: $VERSION"
+
+# The suite is black box: it builds the binary, stages a fixture at 0444 in a
+# 0555 directory and drives it over HTTP. Running it here is not redundant with
+# running it on the box — this catches a broken change before anything is
+# copied anywhere, and costs about six seconds.
+command -v go >/dev/null 2>&1 || die "go not found on PATH; cannot run the preflight test"
+if ! TEST_OUT=$(make test 2>&1); then
+	printf '%s\n' "$TEST_OUT" | tail -30 | sed 's/^/       /'
+	die "make test failed locally; nothing was built or copied"
+fi
+ok "make test: PASS locally"
+
+# ---------------------------------------------------------------------------
+# 2. Remote preflight — capture what is live now, so a rollback has a target
+# ---------------------------------------------------------------------------
+
+step "Remote preflight ($SSH_HOST)"
+
+remote true 2>/dev/null || die "cannot reach $SSH_HOST over ssh"
+ok "ssh reachable"
+
+remote "systemctl cat $SERVICE >/dev/null 2>&1" \
+	|| die "$SERVICE is not installed on $SSH_HOST"
+
+remote "test -x '$REMOTE_API/$BINARY'" \
+	|| die "no binary at $REMOTE_API/$BINARY — this script replaces an existing install, it does not bootstrap one"
+
+remote "test -x '$REMOTE_GO/go'" \
+	|| die "no Go toolchain at $REMOTE_GO/go on the box.
+       The build happens there on purpose (CGO/glibc); see the header. Install
+       Go, or build locally with 'make build-ubuntu' and install by hand."
+REMOTE_GO_VERSION=$(remote "$REMOTE_GO/go version")
+ok "toolchain: $REMOTE_GO_VERSION"
+
+# The baseline. Everything after the install is judged against this, and the
+# data half of it is the assertion that matters most: a binary deploy must not
+# move the databases. If it does, something restarted into a different release
+# and the two deploy paths have collided.
+BEFORE_HEALTH=$(remote "curl -sf --max-time 10 $HEALTH_URL") \
+	|| die "the service is not healthy before we start; fix that first — a rollback needs somewhere to roll back to"
+
+BEFORE_VERSION=$(printf '%s' "$BEFORE_HEALTH" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version","?"))')
+ok "currently running: $BEFORE_VERSION"
+python3 - "$BEFORE_HEALTH" <<'PY'
+import json, sys
+h = json.loads(sys.argv[1])
+for lang, db in sorted(h.get("databases", {}).items()):
+    release = db["path"].rsplit("/", 2)[-2]
+    print(f'           {lang}: {db["rows"]} rows  {db["sha256"][:16]}…  {release}')
+PY
+
+if [ "$BEFORE_VERSION" = "$VERSION" ]; then
+	warn "the box is already running $VERSION — this will rebuild and reinstall the same version string"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Confirm
+# ---------------------------------------------------------------------------
+
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+BACKUP="$REMOTE_API/$BINARY.bak-$STAMP"
+
+step "About to publish the binary"
+printf '    version      %s  (was %s)\n' "$VERSION" "$BEFORE_VERSION"
+printf '    commit       %s\n' "$(git log -1 --format='%h %s' HEAD)"
+printf '    host         %s\n' "$SSH_HOST"
+printf '    build        on the box, %s\n' "$REMOTE_GO_VERSION"
+printf '    installs to  %s/%s\n' "$REMOTE_API" "$BINARY"
+printf '    backup       %s\n' "$BACKUP"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+	step "Dry run — every check above passed; nothing was built, copied or restarted"
+	exit 0
+fi
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+	printf '\n    Publish? [y/N] '
+	read -r reply
+	case "$reply" in
+	y | Y | yes | YES) ;;
+	*) echo "    aborted"; exit 1 ;;
+	esac
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Build on the box
+# ---------------------------------------------------------------------------
+# Under /tmp and removed on exit, so a production host does not accumulate
+# source trees. Nothing here touches $REMOTE_API until the build and the test
+# have both passed.
+
+step "Building $VERSION on the box"
+
+REMOTE_BUILD=$(remote "mktemp -d /tmp/bitcal-build.XXXXXX")
+
+# git archive rather than rsync: exactly the committed tree, no .git, no build
+# artefacts, no editor droppings.
+git archive --format=tar HEAD | remote "tar -x -C '$REMOTE_BUILD'" \
+	|| die "could not export the source tree to the box"
+ok "exported HEAD to $REMOTE_BUILD"
+
+if ! BUILD_OUT=$(remote "cd '$REMOTE_BUILD' && PATH=$REMOTE_GO:\$PATH make build VERSION='$VERSION' 2>&1"); then
+	printf '%s\n' "$BUILD_OUT" | tail -30 | sed 's/^/       /'
+	die "the build failed on the box; nothing was installed"
+fi
+ok "built $BINARY"
+
+# The same suite again, on the target. This is the layer that proves the build
+# tag, the read-only open and the boot probe all work against the box's own
+# libc and kernel — none of which the local run can speak for.
+if ! REMOTE_TEST_OUT=$(remote "cd '$REMOTE_BUILD' && PATH=$REMOTE_GO:\$PATH make test 2>&1"); then
+	printf '%s\n' "$REMOTE_TEST_OUT" | tail -30 | sed 's/^/       /'
+	die "make test failed ON THE BOX; nothing was installed.
+       A local pass and a remote failure means the difference is the platform —
+       look at CGO, the fts5 tag, and the glibc version before anything else."
+fi
+ok "make test: PASS on the box"
+
+# Prove the thing that was just built actually reports the version we asked
+# for, before it replaces a working binary. This is the check that catches the
+# `0.1.0-unknown` failure: the exported tree has no .git, so a VERSION that
+# failed to reach the Makefile shows up here rather than in /health afterwards.
+BUILT_VERSION=$(remote "'$REMOTE_BUILD/$BINARY' --version 2>/dev/null || true")
+if [ -z "$BUILT_VERSION" ]; then
+	# The binary has no --version flag today; fall back to the string table.
+	BUILT_VERSION=$(remote "strings '$REMOTE_BUILD/$BINARY' | grep -Fx '$VERSION' | head -1 || true")
+fi
+if [ -n "$BUILT_VERSION" ]; then
+	ok "the built binary carries $VERSION"
+else
+	warn "could not confirm the version string inside the binary before install"
+	warn "  /health after the restart is the authoritative check — it is asserted below"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Install
+# ---------------------------------------------------------------------------
+# Back up first, then rename over the target. The rename matters: writing over
+# a running executable in place fails with ETXTBSY, while a rename replaces the
+# directory entry and lets the running process keep its inode until it exits.
+
+step "Installing"
+
+remote "cp -p '$REMOTE_API/$BINARY' '$BACKUP'" \
+	|| die "could not back up the running binary; refusing to install without a rollback target"
+ok "backed up the running binary to $(basename "$BACKUP")"
+
+remote "cp '$REMOTE_BUILD/$BINARY' '$REMOTE_API/$BINARY.new' \
+	&& chown root:root '$REMOTE_API/$BINARY.new' \
+	&& chmod 0755 '$REMOTE_API/$BINARY.new' \
+	&& mv -f '$REMOTE_API/$BINARY.new' '$REMOTE_API/$BINARY'" \
+	|| die "could not install the new binary; the running one is untouched and still in place"
+ok "installed $REMOTE_API/$BINARY (root:root 0755)"
+
+# ---------------------------------------------------------------------------
+# 6. Restart
+# ---------------------------------------------------------------------------
+
+rollback() {
+	printf '\n%s==> Rolling back to %s%s\n' "$BOLD" "$BEFORE_VERSION" "$OFF"
+	remote "cp -p '$BACKUP' '$REMOTE_API/$BINARY.rollback' \
+		&& chown root:root '$REMOTE_API/$BINARY.rollback' \
+		&& chmod 0755 '$REMOTE_API/$BINARY.rollback' \
+		&& mv -f '$REMOTE_API/$BINARY.rollback' '$REMOTE_API/$BINARY' \
+		&& systemctl reset-failed $SERVICE 2>/dev/null; systemctl restart $SERVICE" || true
+
+	if [ "$(remote "bash -s" -- "$HEALTH_URL" 30 <<'REMOTE' || true
+set -u
+url=$1; end=$(( $(date +%s) + $2 ))
+while [ "$(date +%s)" -lt "$end" ]; do
+	curl -sf --max-time 3 "$url" >/dev/null 2>&1 && { echo HEALTHY; exit 0; }
+	sleep 0.5
+done
+echo DOWN
+REMOTE
+	)" = "HEALTHY" ]; then
+		NOW=$(remote "curl -sf --max-time 5 $HEALTH_URL" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version","?"))' 2>/dev/null || echo "?")
+		ok "rolled back; $NOW is serving again"
+	else
+		warn "ROLLBACK DID NOT COME UP — the service needs attention now"
+		warn "  ssh $SSH_HOST 'journalctl -u $SERVICE -n 50 --no-pager'"
+		remote "journalctl -u $SERVICE -n 30 --no-pager" 2>/dev/null | sed 's/^/       /' || true
+	fi
+}
+
+step "Restarting"
+
+# Same NRestarts trick as publish-db.sh: a manual restart does not increment it,
+# so any increase afterwards means systemd is restarting a process that keeps
+# dying, and the failure is reported in seconds rather than at the timeout.
+RESTARTS_BEFORE=$(remote "systemctl show $SERVICE -p NRestarts --value 2>/dev/null || echo 0")
+
+remote "systemctl restart $SERVICE" || { rollback; die "restart failed"; }
+
+START=$(date +%s)
+WAIT_RESULT=$(remote "bash -s" -- "$SERVICE" "$HEALTH_URL" "$RESTARTS_BEFORE" 45 <<'REMOTE' || true
+set -u
+service=$1; url=$2; baseline=$3; timeout=$4
+end=$(( $(date +%s) + timeout ))
+while [ "$(date +%s)" -lt "$end" ]; do
+	if curl -sf --max-time 3 "$url" >/dev/null 2>&1; then
+		echo HEALTHY
+		exit 0
+	fi
+	now=$(systemctl show "$service" -p NRestarts --value 2>/dev/null || echo 0)
+	if [ "${now:-0}" -gt "${baseline:-0}" ]; then
+		echo CRASHLOOP
+		exit 0
+	fi
+	sleep 0.5
+done
+echo TIMEOUT
+REMOTE
+)
+ELAPSED=$(( $(date +%s) - START ))
+
+if [ "$WAIT_RESULT" != "HEALTHY" ]; then
+	case "$WAIT_RESULT" in
+	CRASHLOOP) warn "the service is crash-looping on the new binary (${ELAPSED}s)" ;;
+	*) warn "the service did not answer /health within ${ELAPSED}s" ;;
+	esac
+	remote "journalctl -u $SERVICE -n 25 --no-pager" 2>/dev/null | sed 's/^/       /' || true
+	rollback
+	die "publish failed: the new binary did not come up."
+fi
+ok "healthy after ${ELAPSED}s"
+
+# ---------------------------------------------------------------------------
+# 7. Verify — the version moved and the data did not
+# ---------------------------------------------------------------------------
+# Two assertions, and the second is the one worth writing down. publish-db.sh
+# proves a data release changed the data; this proves a binary release did not.
+# The two paths are independent and they have already drifted once — on
+# 2026-08-09 the box served freshly published artifacts for about 35 minutes
+# while still running the previous binary. A binary deploy that quietly moved
+# the databases would be indistinguishable from a correct one, from the outside,
+# until someone compared hashes. So compare them here, every time.
+
+step "Verifying"
+
+AFTER_HEALTH=$(remote "curl -s --max-time 10 $HEALTH_URL")
+
+if ! VERIFY_OUT=$(python3 - "$VERSION" "$BEFORE_HEALTH" "$AFTER_HEALTH" <<'PY'
+import json, sys
+
+want_version, before, after = sys.argv[1], json.loads(sys.argv[2]), json.loads(sys.argv[3])
+problems, notes = [], []
+
+if after.get("status") != "ok":
+    problems.append(f'status is {after.get("status")!r}, want "ok"')
+
+got = after.get("version")
+if got != want_version:
+    problems.append(f'version is {got!r}, want {want_version!r} — the restart did not pick up the new binary')
+else:
+    notes.append(f'version {before.get("version")!r} -> {got!r}')
+
+# The data must be byte-for-byte the file that was already being served.
+b_dbs, a_dbs = before.get("databases", {}), after.get("databases", {})
+if set(b_dbs) != set(a_dbs):
+    problems.append(f'the set of databases changed: {sorted(b_dbs)} -> {sorted(a_dbs)}')
+
+for lang in sorted(set(b_dbs) & set(a_dbs)):
+    b, a = b_dbs[lang], a_dbs[lang]
+    moved = []
+    if b["sha256"] != a["sha256"]:
+        moved.append(f'sha256 {b["sha256"][:16]}… -> {a["sha256"][:16]}…')
+    if b["rows"] != a["rows"]:
+        moved.append(f'rows {b["rows"]} -> {a["rows"]}')
+    if b["path"] != a["path"]:
+        moved.append(f'path {b["path"]} -> {a["path"]}')
+    if moved:
+        problems.append(
+            f'{lang}: a binary deploy moved the data — ' + '; '.join(moved) + '\n'
+            f'         Nothing here publishes databases. Either publish-db.sh ran\n'
+            f'         concurrently, or the current symlink changed underneath us.')
+    else:
+        notes.append(f'{lang}: {a["rows"]} rows, sha256 unchanged, same release directory')
+
+    fts = a.get("fts", {})
+    if not fts.get("consistent") or fts.get("indexed") != a["rows"]:
+        problems.append(f'{lang}: index covers {fts.get("indexed")} of {a["rows"]} rows')
+
+print("\n".join(notes))
+if problems:
+    print("PROBLEMS", file=sys.stderr)
+    print("\n".join("  " + p for p in problems), file=sys.stderr)
+    sys.exit(1)
+PY
+); then
+	printf '%s\n' "$VERIFY_OUT" | sed 's/^/       /'
+	printf '%s\n' "$AFTER_HEALTH" | sed 's/^/       /'
+	rollback
+	die "/health does not describe the binary that was just installed, or the data moved."
+fi
+printf '%s\n' "$VERIFY_OUT" | while IFS= read -r line; do [ -n "$line" ] && ok "$line"; done
+
+# One real request through the real router, because /health does not exercise
+# the database read path or the FTS module. A binary built without -tags fts5
+# cannot exist (fts5_required.go refuses to compile), so this is defence in
+# depth rather than a gap — but it is the assertion that would catch a driver
+# or artifact problem that only appears under a query.
+API_KEY=$(remote "sed -n 's/^API_KEYS=//p' /etc/bitcal/api.env | cut -d, -f1")
+if [ -n "$API_KEY" ]; then
+	SEARCH_TOTAL=$(remote "curl -s --max-time 10 -H 'X-API-KEY: $API_KEY' --get \
+		--data-urlencode 'q=биткоин' --data-urlencode 'lang=ru' \
+		'http://127.0.0.1:3000/api/search' | jq -r '.pagination.total // 0'")
+	if [ "${SEARCH_TOTAL:-0}" -gt 0 ]; then
+		ok "search works through the new binary (ru 'биткоин' -> $SEARCH_TOTAL)"
+	else
+		warn "search returned nothing through the new binary — check the fts5 build tag"
+		remote "journalctl -u $SERVICE -n 25 --no-pager" 2>/dev/null | sed 's/^/       /' || true
+		rollback
+		die "the new binary cannot serve search; rolled back."
+	fi
+else
+	warn "could not read an API key from /etc/bitcal/api.env; skipping the search assertion"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Prune
+# ---------------------------------------------------------------------------
+
+step "Pruning old binaries (keeping $KEEP)"
+
+PRUNED=$(remote "bash -s" -- "$REMOTE_API" "$BINARY" "$KEEP" <<'REMOTE'
+set -euo pipefail
+dir="$1"; binary="$2"; keep="$3"
+cd "$dir" || exit 0
+# Names end in a UTC timestamp, so lexical order is chronological.
+mapfile -t all < <(find . -maxdepth 1 -mindepth 1 -name "$binary.bak-*" -printf '%f\n' | sort)
+count=${#all[@]}
+[ "$count" -le "$keep" ] && exit 0
+for f in "${all[@]:0:$((count - keep))}"; do
+	rm -f "$dir/$f" && echo "$f"
+done
+REMOTE
+)
+if [ -n "$PRUNED" ]; then
+	printf '%s\n' "$PRUNED" | sed 's/^/       removed /'
+else
+	ok "nothing to prune"
+fi
+
+REMAINING=$(remote "ls -1 $REMOTE_API/$BINARY.bak-* 2>/dev/null | wc -l | tr -d ' '")
+
+# ---------------------------------------------------------------------------
+
+step "Published $VERSION"
+printf '    %s previous binaries retained, rollback target %s\n' "$REMAINING" "$(basename "$BACKUP")"
+printf '    roll back by hand: ssh %s \"cp -p %s %s/%s && systemctl restart %s\"\n' \
+	"$SSH_HOST" "$BACKUP" "$REMOTE_API" "$BINARY" "$SERVICE"
+printf '    verify by hand:    ssh %s \"curl -s %s | jq .\"\n' "$SSH_HOST" "$HEALTH_URL"

--- a/deploy/publish-db.sh
+++ b/deploy/publish-db.sh
@@ -9,6 +9,7 @@
 #   local  preflight  checksums + validate.py + scoped git state
 #   remote stage      copy into releases/<ts>.incoming, verify, permission, rename
 #   remote validate   run validate.py against the STAGED copy, not just the source
+#   local  schema     the API's own test, against the staged copy — see below
 #   remote flip       symlink, then restart (mandatory — see below)
 #   remote verify     /health hashes, FTS coverage, and a vocabulary assertion
 #   remote prune      keep the last N releases
@@ -27,12 +28,25 @@
 # sidecar or flips the WAL header byte after validation already passed. The
 # second run is against the bytes that will actually be served.
 #
+# The schema guard is why this script knows about `go test`. validate.py checks
+# that the data is internally consistent; it has no opinion about whether this
+# API can express it. Canonical gained a mandatory `category` column on
+# 2026-08-09, the Event struct did not, and the column shipped inside the
+# artifact and reached no response — with validate.py passing and `make test`
+# green throughout, because the suite's own fixture had no such column either.
+# TestFixtureSchemaMatchesCanonical compares the fixture's schema against a real
+# artifact, so pointing it at the staged copy turns "someone notices the schema
+# changed" into a check that fires at the one moment a schema change is expected
+# to be reviewed: release. It runs before the flip, so a failure costs nothing —
+# the running service is untouched.
+#
 # Usage:
 #   ./publish-db.sh                    # publish, with a confirmation prompt
 #   ./publish-db.sh --dry-run          # every check, no staging, no flip
 #   ./publish-db.sh --yes              # no prompt (for a future cron/CI caller)
 #   ./publish-db.sh --keep 10
 #   ./publish-db.sh --source /path/to/calendar/dbs --host root@example
+#   ./publish-db.sh --allow-schema-drift   # publish data the API cannot yet emit
 #
 set -euo pipefail
 
@@ -47,6 +61,11 @@ API_URL="http://127.0.0.1:3000/api"
 KEEP=5
 DRY_RUN=0
 ASSUME_YES=0
+ALLOW_SCHEMA_DRIFT=0
+
+# The repo this script lives in, so the schema guard can find the Go suite
+# regardless of where it was invoked from.
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 DBS=(events_ru.db events_en.db)
 
@@ -55,10 +74,19 @@ DBS=(events_ru.db events_en.db)
 # printed loudly, because a *drop to zero* means the FTS tokenizer stopped
 # handling that script, which nothing else in this script would catch.
 # Cyrillic is the one that actually exercises the tokenizer.
+#
+# Both numbers were re-measured against release 20260810T131954Z on 2026-08-10
+# and both had drifted. EN fell 450 -> 389 because the `bitcoin` tag was retired
+# in canonical: events_fts indexes the tags column, so removing the tag from
+# ~76% of rows removed those matches. `bitcoin` survives as a category value,
+# which the FTS index does not cover. RU fell 246 -> 244 with ordinary edits.
+# The previous release printed the warning below exactly as designed and the
+# constants were simply never updated — which is the failure mode this comment
+# exists to make harder.
 VOCAB_RU_TERM="биткоин"
 VOCAB_EN_TERM="bitcoin"
-VOCAB_RU_LAST=246
-VOCAB_EN_LAST=450
+VOCAB_RU_LAST=244
+VOCAB_EN_LAST=389
 
 # --- argument parsing -------------------------------------------------------
 
@@ -69,7 +97,8 @@ while [ $# -gt 0 ]; do
 	--keep) KEEP="$2"; shift 2 ;;
 	--dry-run) DRY_RUN=1; shift ;;
 	--yes | -y) ASSUME_YES=1; shift ;;
-	-h | --help) sed -n '2,40p' "$0"; exit 0 ;;
+	--allow-schema-drift) ALLOW_SCHEMA_DRIFT=1; shift ;;
+	-h | --help) sed -n '2,49p' "$0"; exit 0 ;;
 	*) echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
 	esac
 done
@@ -326,6 +355,74 @@ fi
 remote "rm -rf '$REMOTE_TMP'"
 printf '%s\n' "$STAGED_OUT" | sed 's/^/       /'
 ok "validate.py: PASS on the staged artifact"
+
+# ---------------------------------------------------------------------------
+# 5b. Schema guard — can this API actually express what is being published?
+# ---------------------------------------------------------------------------
+# validate.py answers "is this data sound"; this answers "can the service emit
+# it". They are different questions and the second one had no owner, which is
+# how a mandatory column shipped into production and reached no response.
+#
+# Pulled back rather than checked in place: the box has no Go toolchain and no
+# source tree, and it should stay that way. The file that comes back is the one
+# that will be served, so the copy is the point rather than an inconvenience.
+
+step "Schema guard (the API's own test, against the staged copy)"
+
+schema_guard_failed=0
+if ! command -v go >/dev/null 2>&1; then
+	if [ "$ALLOW_SCHEMA_DRIFT" -eq 1 ]; then
+		warn "go not found; skipping the schema guard because --allow-schema-drift was given"
+	else
+		die "go not found on PATH, so the schema guard cannot run.
+       This check is what stops a new canonical column shipping into an API that
+       cannot emit it. Install Go, or re-run with --allow-schema-drift if you
+       have decided to publish data ahead of the service."
+	fi
+elif [ ! -d "$REPO_ROOT/tests" ]; then
+	warn "no tests/ directory under $REPO_ROOT; skipping the schema guard"
+else
+	SCHEMA_TMP=$(mktemp -d "${TMPDIR:-/tmp}/bitcal-schema.XXXXXX")
+	trap 'rm -rf "$SCHEMA_TMP"; close_ssh' EXIT
+
+	for db in "${DBS[@]}"; do
+		scp -q "${SSH_OPTS[@]}" "$SSH_HOST:$TARGET/$db" "$SCHEMA_TMP/$db" \
+			|| die "could not fetch $db back from the staged release for the schema check"
+
+		# Column sets must match; column *order* legitimately differs between
+		# the two languages, so the test compares by name and both files are
+		# expected to pass.
+		if GUARD_OUT=$(cd "$REPO_ROOT" && BITCAL_CANONICAL_DB="$SCHEMA_TMP/$db" \
+			CGO_ENABLED=1 go test -tags fts5 -count=1 \
+			-run TestFixtureSchemaMatchesCanonical ./tests 2>&1); then
+			ok "$db: schema matches what the API models"
+		else
+			printf '%s\n' "$GUARD_OUT" | sed 's/^/       /'
+			schema_guard_failed=1
+		fi
+	done
+	rm -rf "$SCHEMA_TMP"
+	trap close_ssh EXIT
+fi
+
+if [ "$schema_guard_failed" -eq 1 ]; then
+	if [ "$ALLOW_SCHEMA_DRIFT" -eq 1 ]; then
+		warn "the staged artifact's schema does not match the API's model, and"
+		warn "--allow-schema-drift was given — publishing anyway. The columns"
+		warn "named above will ship inside the artifact and reach no response."
+	else
+		die "the staged artifact's schema does not match what this API models.
+       Nothing was flipped and the running service is untouched; the release
+       directory is at $TARGET.
+
+       This is the check working. Add the column to Event in database.go and to
+       the fixture in tests/main_test.go, let TestEventStructCoversEveryColumn
+       tell you what else to fix, ship the binary, then publish again.
+
+       If you have decided to publish the data first and update the API after,
+       re-run with --allow-schema-drift."
+	fi
+fi
 
 # ---------------------------------------------------------------------------
 # 6. Flip and restart

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -67,8 +67,10 @@ Detailed information for each endpoint is provided below.
 
 ## The event object
 
-Every endpoint that returns events returns objects of this shape. Four points are worth
-reading before writing a client, because all four have changed:
+Every endpoint that returns events returns objects of this shape — including `/search`, which
+until 2026-08-10 silently omitted `category`, `created_at` and `updated_at` because it
+enumerates its columns by hand. Several fields below are worth reading before writing a
+client, because they have changed:
 
 | Field | Type | Notes |
 |---|---|---|
@@ -80,6 +82,7 @@ reading before writing a client, because all four have changed:
 | `media` | string \| null | A JSON array encoded as a string, or `null` when the event has no media. Never `""` and never `"[]"` — absence is exactly one value. |
 | `references` | string \| null | Same encoding and same null rule as `media`. |
 | `url_path` | string | `/<date>/<slug>/`, e.g. `"/2013-08-09/hal-finneys-last-post/"`. The site's page path and the cross-language join key. **Note the leading slash** — joining it onto a base URL with another `/` yields a double slash. |
+| `category` | string | The event's single classification, from a closed list of 14: `archives`, `bitcoin`, `first`, `holiday`, `legal`, `lightning`, `macro`, `mining`, `mustread`, `obituary`, `price`, `privacy`, `scam`, `software`. Always present and never empty. **Do not derive it from `tags[0]`** — that inference used to work and is now wrong, because tag order carries no meaning. In particular `bitcoin` is a category with no corresponding tag left in the data at all, so `/api/events/tags/bitcoin` returns nothing while 148 RU and 82 EN events are `category: "bitcoin"`. |
 | `created_at` | string \| null | RFC 3339, or `null`. Bookkeeping about the row, not about the event; most rows have no value. |
 | `updated_at` | string \| null | Same. |
 
@@ -93,6 +96,7 @@ reading before writing a client, because all four have changed:
   "media": "[\"https://i.nostr.build/dwoR3.png\"]",
   "references": "[\"https://web.archive.org/web/20240207194838/https://bitcointalk.org/...\"]",
   "url_path": "/2013-08-09/hal-finneys-last-post/",
+  "category": "archives",
   "created_at": null,
   "updated_at": null
 }
@@ -223,6 +227,7 @@ Error responses will typically be in JSON format, like:
               "media": null,
               "references": "[\"https://bitcoin.org/bitcoin.pdf\"]",
               "url_path": "/2008-11-01/bitcoin-whitepaper-published/",
+              "category": "mustread",
               "created_at": null,
               "updated_at": null
             }
@@ -336,6 +341,7 @@ Error responses will typically be in JSON format, like:
             "media": null,
             "references": "[\"https://bitcoin.org/bitcoin.pdf\"]",
             "url_path": "/2008-11-01/bitcoin-whitepaper-published/",
+            "category": "mustread",
             "created_at": null,
             "updated_at": null
           }
@@ -421,6 +427,7 @@ Error responses will typically be in JSON format, like:
               "media": "[\"https://example.com/pizza.webp\"]",
               "references": "[\"https://bitcointalk.org/...\"]",
               "url_path": "/2010-05-22/bitcoin-pizza-day/",
+              "category": "bitcoin",
               "created_at": "2026-08-08T09:59:56Z",
               "updated_at": "2026-08-08T09:59:56Z"
             }

--- a/docs/DatabaseDocumentation.md
+++ b/docs/DatabaseDocumentation.md
@@ -53,6 +53,23 @@ Present in both database files, with identical definitions.
 | `created_at`  | `datetime`    |               | Row bookkeeping. `NULL` on most rows. |
 | `updated_at`  | `datetime`    |               | Row bookkeeping. `NULL` on most rows. |
 | `url_path`    | `TEXT`        | `UNIQUE` index | `/<date>/<slug>/`. The website's page path and the cross-language join key. |
+| `category`    | `TEXT`        | none in the DDL | The event's single classification, from a closed list of 14. Added to canonical 2026-08-09. **Mandatory by validator invariant 13, not by the schema** — the column is declared `notnull=0`, so the data is clean because the publisher checks it, not because SQLite would refuse otherwise. Measured 2026-08-10 across both artifacts: 0 `NULL`, 0 `''`, 0 values outside the 14, in 1,146 rows. |
+
+**On `category`.** The 14 values are `archives`, `bitcoin`, `first`, `holiday`, `legal`,
+`lightning`, `macro`, `mining`, `mustread`, `obituary`, `price`, `privacy`, `scam`,
+`software`. It replaces an older convention in which consumers read the classification out of
+`tags[0]`; tag order no longer carries meaning and that inference is now wrong. `bitcoin` is
+the clearest case — it exists as a category (148 RU, 82 EN) and **no longer exists as a tag at
+all**, so a hard-coded `tag=bitcoin` query returns zero rows.
+
+The two languages disagree about the category of 62 of the 500 events they share by
+`url_path`. That is catalogued in canonical's README and is data, not a bug — but a
+two-language filter built on this column will return genuinely different sets.
+
+**The two languages declare these columns in different orders.** RU stores `media` fourth, EN
+eighth; the names and types match but the positions do not. Anything reading this schema must
+match on **name** — a positional assumption is correct against one artifact and silently wrong
+against the other.
 
 **On `date`'s declared type.** SQLite has no date type; the value is text. But the column is
 *declared* `date`, and `mattn/go-sqlite3` converts any column declared `date`, `datetime` or
@@ -68,6 +85,14 @@ because those really are timestamps.
 *   `idx_events_tags` on `tags` — of little use, since `tags` holds a JSON blob
 *   `idx_events_url_path` on `url_path`, **UNIQUE**
 *   the implicit index on `id` as `PRIMARY KEY`
+
+**There is no index on `category`**, in either language. Verified 2026-08-10 against both
+released artifacts: `EXPLAIN QUERY PLAN SELECT * FROM events WHERE category=?` reports
+`SCAN events`. A filter on this column is a full table scan. That is fine at 565 and 581 rows —
+microseconds — and it is no worse than the date filters, which cannot use `idx_events_date`
+either, or the tag filter, which runs `json_each` over every row. It is recorded here so that
+nobody argues for a feature on indexed-lookup grounds that do not hold. This service is
+read-only and **cannot create the index**; that would be a change to canonical.
 
 ## Full-text search: `events_fts`
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -80,6 +80,12 @@ There is no `PORT` variable any more; use `LISTEN_ADDR`.
 4.  runs `validate.py` again **against the staged copy**, because the artifact is a copy and a
     copy step that opens a database read-write can leave a sidecar or flip the WAL header byte
     after the source already passed;
+4b. pulls the staged databases back and runs `TestFixtureSchemaMatchesCanonical` against them,
+    which is the check that stops a new canonical column shipping into an API that cannot emit
+    it. `validate.py` asks whether the data is sound; this asks whether this service can
+    express it, and nothing owned that question until `category` shipped invisibly. A failure
+    here aborts **before** the symlink flip, so the running service is untouched; override with
+    `--allow-schema-drift` if you have decided to publish data ahead of the binary;
 5.  flips the symlink and restarts — the restart is mandatory, SQLite holds an open file
     descriptor and flipping alone leaves the old inode being served;
 6.  verifies `/health` names the new release, that its hashes match what was published, and
@@ -94,6 +100,49 @@ restarts it. A rejected release directory is left in place for inspection.
 The `deploy` user owns the artifacts but cannot be logged into (`nologin`, no home, no keys) —
 it exists so that `bitcal` cannot write them. Publishing therefore connects as `root` and
 chowns afterwards.
+
+## Releasing a new binary
+
+```sh
+./deploy/publish-api.sh --dry-run   # every check, nothing built or installed
+./deploy/publish-api.sh             # build, install, verify, with a prompt
+```
+
+`publish-api.sh` is the counterpart to `publish-db.sh` and their scopes do not overlap: that
+one ships data and never rebuilds, this one ships a binary and never touches the data. It
+automates the procedure that was walked by hand for `ec6b5de`, and it:
+
+1.  refuses to build a dirty or unpushed tree — the binary is exported from `HEAD` with
+    `git archive`, so uncommitted work would be absent from a binary whose version string
+    names the commit as though it were there (`--allow-dirty` overrides);
+2.  runs `make test` locally first, so a broken change costs six seconds rather than a
+    round trip;
+3.  exports `HEAD` to a temp directory **on the box** and builds it there. CGO ties the
+    binary to the C library it was built against, so building on the target makes the glibc
+    match true by construction rather than by remembering to use `make build-ubuntu`. Nothing
+    persists: no source tree, no build output. `VERSION` is passed explicitly because the
+    exported tree has no `.git` and the Makefile's fallback would silently yield
+    `0.1.0-unknown`;
+4.  runs `make test` **again on the box**, which is the layer that proves the `fts5` tag, the
+    read-only open and the boot probe against the target's own libc;
+5.  backs the running binary up to `bitcal-api.bak-<UTC timestamp>`, then *renames* the new
+    one over it — writing over a busy executable in place fails with `ETXTBSY`, while a
+    rename swaps the directory entry and leaves the running process on its old inode;
+6.  restarts, watching `NRestarts` so a crash-loop is reported in seconds rather than at the
+    timeout;
+7.  verifies `/health` reports the new `version` **and that the database sha256s, row counts
+    and release paths are unchanged**. A binary deploy must not move the data; if those
+    hashes moved, the two release paths have collided and that is worth knowing immediately;
+8.  sends one real search through the new binary, since `/health` does not exercise the query
+    path or the FTS module;
+9.  prunes old `.bak` binaries, keeping `--keep N` (default 5).
+
+**Any failure after the install rolls back automatically** by restoring the `.bak` binary and
+restarting.
+
+The two paths are independent, so the box can serve new data on an old binary or the reverse.
+That is allowed — on 2026-08-09 it did exactly that for about 35 minutes — but when
+diagnosing anything, check both halves of `/health`.
 
 ## Startup checks
 

--- a/main.go
+++ b/main.go
@@ -549,7 +549,23 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 	searchSQL := `
 		-- "references" is a SQL reserved word: unquoted, SQLite refuses to
 		-- parse the statement and every search returns 500.
-		SELECT e.id, e.date, e.title, e.description, e.tags, e.media, e."references", e.url_path, fts.rank
+		--
+		-- This list is the one place in the service that names columns by hand;
+		-- every other handler goes through db.Model(&Event{}) and picks up a new
+		-- field for free. So this is the statement that silently drops one, and
+		-- it had dropped three: category, created_at and updated_at all reached
+		-- callers empty while /api/events returned them correctly.
+		-- TestEventStructCoversEveryColumn covers search specifically for that
+		-- reason, and checks the values rather than the keys, because a struct
+		-- field the SELECT never fetched still marshals to "" or null.
+		--
+		-- fts.rank is deliberately not selected: nothing scans it — there is no
+		-- Rank field on Event — and SQLite orders by it perfectly well without
+		-- it appearing here. Selecting it only implied a field that does not
+		-- exist. Exposing rank as JSON would be a new contract decision: the
+		-- value is FTS5-internal, negative, and incomparable across queries.
+		SELECT e.id, e.date, e.title, e.description, e.tags, e.media, e."references",
+		       e.url_path, e.category, e.created_at, e.updated_at
 		FROM events e
 		JOIN events_fts fts ON e.id = fts.rowid
 		WHERE events_fts MATCH ?

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -100,6 +100,13 @@ func TestEventContract(t *testing.T) {
 	if e.URLPath != "/1881-09-29/birthday-of-ludwig-von-mises/" {
 		t.Errorf("url_path: want the event's path, got %q", e.URLPath)
 	}
+	// The single mandatory classification, and what the website colours and
+	// filters by. Pinned to a value that is not this row's first tag, because
+	// consumers used to derive category from tags[0] and that inference is now
+	// wrong — a fixture where the two agreed would keep it looking correct.
+	if e.Category != "holiday" {
+		t.Errorf("category: want %q, got %q", "holiday", e.Category)
+	}
 	// Absence is null and only null — never "" and never "[]".
 	if e.Media != nil {
 		t.Errorf("media: want null, got %q", *e.Media)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -165,7 +165,8 @@ func seedArtifact(path, lang string) error {
 			"references" TEXT,
 			created_at datetime,
 			updated_at datetime,
-			url_path TEXT
+			url_path TEXT,
+			category TEXT
 		)`,
 		`CREATE INDEX idx_events_date ON events(date)`,
 		`CREATE UNIQUE INDEX idx_events_url_path ON events(url_path)`,
@@ -194,9 +195,9 @@ func seedArtifact(path, lang string) error {
 
 	for _, e := range fixtureRows(lang) {
 		if _, err := db.Exec(
-			`INSERT INTO events (id, date, title, description, media, tags, "references", created_at, updated_at, url_path)
-			 VALUES (?,?,?,?,?,?,?,?,?,?)`,
-			e.ID, e.Date, e.Title, e.Description, e.Media, e.Tags, e.References, e.CreatedAt, e.UpdatedAt, e.URLPath,
+			`INSERT INTO events (id, date, title, description, media, tags, "references", created_at, updated_at, url_path, category)
+			 VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+			e.ID, e.Date, e.Title, e.Description, e.Media, e.Tags, e.References, e.CreatedAt, e.UpdatedAt, e.URLPath, e.Category,
 		); err != nil {
 			return err
 		}
@@ -217,6 +218,10 @@ type fixtureRow struct {
 	Media, References    *string
 	CreatedAt, UpdatedAt *string
 	Tags, URLPath        string
+	// Mandatory in canonical by validator invariant 13 — one value per row
+	// from a closed list of 14 — so every fixture row carries one, and each
+	// value below is a real member of that list rather than an invention.
+	Category string
 }
 
 func strptr(s string) *string { return &s }
@@ -237,6 +242,11 @@ func fixtureRows(lang string) []fixtureRow {
 			// Without a five-letter tag here, `_____` matches nothing whether or
 			// not the bug is present, and the test passes vacuously.
 			Tags: `["holiday", "prebitcoin", "price"]`, URLPath: "/1881-09-29/birthday-of-ludwig-von-mises/",
+			// Not `price`, though the row carries that tag: category is a single
+			// mandatory classification and tag order no longer implies it. A
+			// fixture whose category always matched tags[0] would let the very
+			// inference canonical retired keep passing its tests.
+			Category: "holiday",
 		},
 		{
 			ID: 2, Date: "2008-11-01",
@@ -246,6 +256,7 @@ func fixtureRows(lang string) []fixtureRow {
 			References:  strptr(`["https://bitcoin.org/bitcoin.pdf"]`),
 			CreatedAt:   strptr("2026-08-08 09:59:56"), UpdatedAt: strptr("2026-08-08 09:59:56"),
 			Tags: `["bitcoin", "mustread"]`, URLPath: "/2008-11-01/bitcoin-whitepaper-published/",
+			Category: "mustread",
 		},
 		{
 			ID: 3, Date: "2013-08-09",
@@ -254,6 +265,7 @@ func fixtureRows(lang string) []fixtureRow {
 			Media:       nil, References: nil,
 			CreatedAt: nil, UpdatedAt: nil,
 			Tags: `["bitcoin", "archives", "bitcoin"]`, URLPath: "/2013-08-09/a-duplicated-tag-lives-here/",
+			Category: "archives",
 		},
 		{
 			// Shares 2008-11-01 with event 2, and exists only for that. The
@@ -272,6 +284,9 @@ func fixtureRows(lang string) []fixtureRow {
 			Media:       nil, References: nil,
 			CreatedAt: nil, UpdatedAt: nil,
 			Tags: `["archives"]`, URLPath: "/2008-11-01/a-second-event-on-the-same-day/",
+			// Same tag as event 3 but a different category, so that nothing can
+			// pass by treating the two fields as interchangeable.
+			Category: "first",
 		},
 	}
 	if lang == "ru" {
@@ -282,6 +297,7 @@ func fixtureRows(lang string) []fixtureRow {
 			Media:       nil, References: nil,
 			CreatedAt: nil, UpdatedAt: nil,
 			Tags: `["bitcoin"]`, URLPath: "/2020-12-08/ru-only/",
+			Category: "bitcoin",
 		})
 	}
 	return rows
@@ -419,6 +435,7 @@ type event struct {
 	Media       *string `json:"media"`
 	References  *string `json:"references"`
 	URLPath     string  `json:"url_path"`
+	Category    string  `json:"category"`
 	CreatedAt   *string `json:"created_at"`
 	UpdatedAt   *string `json:"updated_at"`
 }

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -1,0 +1,261 @@
+package tests
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEventStructCoversEveryColumn is the general guard, and it exists because
+// the specific bug it generalises shipped invisibly with every check green:
+// canonical gained a `category` column on 2026-08-09, the Event struct did not,
+// and nothing in this suite had an opinion about the difference.
+//
+// It reads the artifact's own schema rather than listing the expected fields by
+// hand, because a hand-written list has to be remembered — and remembering is
+// the step that failed.
+//
+// It runs against /api/search as well as /api/events on purpose. The search
+// handler enumerates its columns in a literal SELECT instead of letting GORM
+// derive them from the struct, so a field can be present in the model, correct
+// on every other endpoint, and still missing from search. A version of this
+// test that checked one endpoint would go green on a half-fix.
+//
+// It asserts the value survived, not merely that the key is there, and that is
+// load-bearing rather than thoroughness. Checking key presence alone cannot see
+// the search half of this bug at all: Category is a plain string on a Go
+// struct, so encoding/json writes `"category":""` whether the SELECT fetched
+// the column or never mentioned it. The same holds for created_at and
+// updated_at, which arrive as a JSON null either way. Presence proves the model
+// has the field; only the value proves the statement went and got it. This was
+// measured, not reasoned about — an earlier draft of this test checked presence
+// only, and passed against a search handler that emitted an empty category for
+// every row.
+func TestEventStructCoversEveryColumn(t *testing.T) {
+	// Columns deliberately not exposed. Empty today. Anything added here needs
+	// a reason written beside it: the point of this test is that an omission
+	// must be a decision someone recorded, not one nobody noticed.
+	notExposed := map[string]string{}
+
+	artifact := filepath.Join(artifactDir, "events_ru.db")
+	columns := eventColumns(t, artifact)
+	if len(columns) == 0 {
+		t.Fatal("pragma table_info(events) returned no columns")
+	}
+
+	for _, ep := range []struct{ name, path string }{
+		// A limit high enough to take every fixture row, because the columns
+		// that are NULL on one row and set on another — media, references, the
+		// timestamps — can only be proven on the row that has them.
+		{"events", "/api/events?lang=ru&limit=100"},
+		{"search", "/api/search?lang=ru&q=bitcoin&limit=100"},
+	} {
+		t.Run(ep.name, func(t *testing.T) {
+			var body struct {
+				Events []map[string]json.RawMessage `json:"events"`
+			}
+			if code := getAs(t, apiKey3, ep.path, &body); code != http.StatusOK {
+				t.Fatalf("%s: want 200, got %d", ep.path, code)
+			}
+			// Without a row there is nothing to inspect, and the test would
+			// pass by measuring nothing at all.
+			if len(body.Events) == 0 {
+				t.Fatalf("%s returned no events; this test cannot measure anything", ep.path)
+			}
+
+			// Which columns this endpoint proved it can carry a real value for.
+			// Collected across every row rather than per row, since a column
+			// that is legitimately NULL here may be set two rows down.
+			proven := map[string]bool{}
+
+			for _, got := range body.Events {
+				id, ok := got["id"]
+				if !ok {
+					t.Fatalf("%s returned an event with no id; nothing can be looked up", ep.path)
+				}
+				stored := eventRow(t, artifact, string(id))
+
+				for _, col := range columns {
+					if _, skip := notExposed[col]; skip {
+						continue
+					}
+					raw, present := got[col]
+					if !present {
+						continue // reported once, below
+					}
+					// A NULL in the artifact proves nothing either way: null is
+					// the correct rendering, so this row cannot distinguish a
+					// fetched column from an unfetched one.
+					if stored[col] == nil {
+						continue
+					}
+					if !isNullOrEmpty(raw) {
+						proven[col] = true
+					}
+				}
+			}
+
+			for _, col := range columns {
+				if why, ok := notExposed[col]; ok {
+					t.Logf("column %q is deliberately not exposed: %s", col, why)
+					continue
+				}
+				if _, present := body.Events[0][col]; !present {
+					t.Errorf("the events table has a %q column and %s does not emit it at all.\n"+
+						"Add the field to Event in database.go — and, for search, to the\n"+
+						"explicit SELECT in ftsSearchHandler, which names its columns by\n"+
+						"hand and will not pick it up otherwise.", col, ep.path)
+					continue
+				}
+				if !proven[col] {
+					t.Errorf("%s emits a %q key but never a value: every row that has one\n"+
+						"stored came back null or empty. The field exists on the model, so\n"+
+						"this is the statement, not the struct — add e.%s to the explicit\n"+
+						"SELECT in ftsSearchHandler, which enumerates its columns by hand.",
+						ep.path, col, col)
+				}
+			}
+		})
+	}
+}
+
+// eventRow reads one row of events by id, keyed by column name, so the test can
+// ask what the artifact actually holds before deciding whether a null in the
+// response is honest or lossy.
+func eventRow(t *testing.T, path, id string) map[string]any {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatalf("opening %s: %v", path, err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT * FROM events WHERE id = ?`, id)
+	if err != nil {
+		t.Fatalf("selecting event %s: %v", id, err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("columns for event %s: %v", id, err)
+	}
+	if !rows.Next() {
+		t.Fatalf("the response named event %s, which is not in the artifact", id)
+	}
+
+	cells := make([]any, len(cols))
+	into := make([]any, len(cols))
+	for i := range cells {
+		into[i] = &cells[i]
+	}
+	if err := rows.Scan(into...); err != nil {
+		t.Fatalf("scanning event %s: %v", id, err)
+	}
+
+	out := make(map[string]any, len(cols))
+	for i, c := range cols {
+		// A stored empty string is indistinguishable from an unfetched one in
+		// the response, so treat it as nothing to prove rather than as a value
+		// the endpoint failed to carry.
+		if s, ok := cells[i].(string); ok && s == "" {
+			continue
+		}
+		out[c] = cells[i]
+	}
+	return out
+}
+
+// isNullOrEmpty reports whether a JSON value carries nothing — the two shapes a
+// dropped column takes, depending on whether its Go field is a pointer.
+func isNullOrEmpty(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s == "" || s == "null" || s == `""`
+}
+
+// TestFixtureSchemaMatchesCanonical closes the loop that TestEventStructCovers-
+// EveryColumn leaves open.
+//
+// That test makes the fixture the contract: whatever the fixture's events table
+// carries, the API must emit. But the fixture is hand-written in main_test.go,
+// so a column added to canonical and not to the fixture leaves both tests green
+// and the API silently short a field. That is exactly how `category` shipped —
+// the suite was self-consistent and wrong.
+//
+// Skipped unless a real artifact is named, because the suite must keep running
+// offline:
+//
+//	BITCAL_CANONICAL_DB=~/code/dump/projects/21ideas/calendar/dbs/events_ru.db \
+//	  go test -tags fts5 -run TestFixtureSchemaMatchesCanonical ./tests
+//
+// Wired into publish-db.sh, which already holds the validated files at release
+// time — the one moment a schema change is expected to be reviewed.
+func TestFixtureSchemaMatchesCanonical(t *testing.T) {
+	path := os.Getenv("BITCAL_CANONICAL_DB")
+	if path == "" {
+		t.Skip("set BITCAL_CANONICAL_DB to a real artifact to compare schemas")
+	}
+
+	canonical := set(eventColumns(t, path))
+	fixture := set(eventColumns(t, filepath.Join(artifactDir, "events_ru.db")))
+
+	for col := range canonical {
+		if !fixture[col] {
+			t.Errorf("canonical has a %q column the test fixture does not model.\n"+
+				"The suite cannot notice a field the API fails to emit if its own\n"+
+				"fixture has no such column. Add it to seedArtifact in main_test.go,\n"+
+				"then let TestEventStructCoversEveryColumn tell you what else to fix.", col)
+		}
+	}
+	for col := range fixture {
+		if !canonical[col] {
+			t.Errorf("the fixture models a %q column canonical no longer has; the\n"+
+				"suite is pinning a schema that does not exist, and Test A would\n"+
+				"require the API to emit a column it cannot read.", col)
+		}
+	}
+}
+
+// eventColumns reads the column names of the events table straight out of the
+// artifact. Names, not positions: the two languages genuinely order their
+// columns differently — RU stores media fourth, EN eighth — so anything
+// positional would be correct on one artifact and wrong on the other.
+func eventColumns(t *testing.T, path string) []string {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatalf("opening %s: %v", path, err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT name FROM pragma_table_info('events')`)
+	if err != nil {
+		t.Fatalf("pragma table_info(events): %v", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scanning column name: %v", err)
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading column names: %v", err)
+	}
+	return names
+}
+
+func set(items []string) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, it := range items {
+		m[it] = true
+	}
+	return m
+}


### PR DESCRIPTION
Canonical gained a mandatory `category` column on 2026-08-09. The `Event` struct never
gained it, so the column shipped inside every artifact and reached no response — with
`validate.py` passing and `make test` green throughout.

- `database.go` — add `Category`; `main.go` — add `category`, `created_at` and `updated_at`
  to the hand-written FTS `SELECT`, which had been dropping all three.
- Two tests. `TestEventStructCoversEveryColumn` reads the artifact's own schema and requires
  each column to reach the JSON on both `/api/events` and `/api/search`. It asserts the
  **value**, not the key: a Go struct marshals every field regardless, so an unfetched column
  still emits `""` or `null`, and a key-presence test cannot see the search half of this bug.
  `TestFixtureSchemaMatchesCanonical` compares the fixture against a real artifact.
- `publish-db.sh` runs that second test against the staged copy before the symlink flip, so a
  new canonical column now blocks the release instead of shipping invisibly.
  `--allow-schema-drift` overrides. Also corrects `VOCAB_EN_LAST` 450→389 and
  `VOCAB_RU_LAST` 246→244, both re-measured against release 20260810T131954Z.
- `publish-api.sh` — the binary release path, transcribed from the procedure hand-walked on
  2026-08-09. Builds on the box (CGO/glibc), tests there, backs the running binary aside,
  installs, restarts, and asserts `/health` shows a new version **and unchanged data**.

Not in this change: the `?category=` filter and `/api/categories`, and the fixture's retired
`bitcoin` tag.

Verified against the real artifacts locally: `category` non-empty on both endpoints, timestamps
present in search, artifacts byte-identical before and after boot. `make test` green; the schema
guard passes against both languages and fails as intended on a drifted schema.
