### PR TITLE
Correct the tag vocabulary in the docs and the fixture

### DIFF
--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -104,27 +104,55 @@ client, because they have changed:
 
 ## Available Tags for Querying
 
-The following tags can be used with the `/events/tags/:tag` endpoint to find relevant events. Note that tag searching is case-insensitive.
+**`GET /api/tags` is the authoritative list.** It returns every tag in the requested language
+with its usage count, straight from the artifact, so it is correct by construction. Prefer it
+to anything written here: as of 2026-08-10 there are **192 distinct tags in each language**,
+and the selection below is an orientation aid, not a catalogue.
 
-*   `clownworld`: Content related to traditional finance, banking sector announcements and activities, mainstream media narratives, and so on.
-*   `cypherpunks`: Events, discussions, quotations, and news pertaining to the cypherpunk movement, including key figures like Satoshi Nakamoto, Hal Finney, David Chaum, and other early adopters, along with significant related activities.
-*   `quotes`: Direct quotations featured within the event descriptions.
-*   `bitcointalk`: Events or discussions from the BitcoinTalk forum.
-*   `ecash`: Content pertaining to DigiCash, e-cash, or similar digital cash systems.
-*   `lightning`: Events, developments, or discussions related to the Lightning Network or Lightning payments.
-*   `onchain`: Events and discussions concerning on-chain Bitcoin transactions.
-*   `obituaries`: Bitcoin obituaries events.
-*   `trading`: Content related to Bitcoin trading, market analysis, or price charts.
-*   `first`: Milestone events marking a 'first' occurrence in the Bitcoin ecosystem.
-*   `scam`: Incidents involving scams, financial losses, or theft within the Bitcoin space.
-*   `hack`: Incidents involving hacks or theft within the Bitcoin space.
-*   `mustread`: Important documents, articles and books deemed essential reading.
-*   `econ`: Discussions and events related to economic theories, principles, or impacts concerning Bitcoin.
-*   `privacy`: Content focusing on privacy aspects, technologies, or discussions within the Bitcoin context.
-*   `development`: Events related to Bitcoin Core releases, protocol upgrades, and technical proposals.
-*   `adoption`: Events highlighting instances of countries, governments, businesses, individuals, or organizations starting to accept or use Bitcoin.
-*   `legal`: For events involving lawsuits, regulations, and government legal actions.
-*   `media`: To specifically categorize mentions of Bitcoin in articles, TV shows, and other media.
+Tag matching on `/events/tags/:tag` is case-insensitive.
+
+> **If you hardcoded tags from an earlier version of this document, re-check them.** Three
+> entries listed here until 2026-08-10 match **nothing** in the data, and a tag with no events
+> is not an error — it is an empty list, indistinguishable from a tag that simply has no events
+> yet. Two of the three have live near-misses that make the mistake look like your typo:
+>
+> | Was documented | Status | Did you mean |
+> |---|---|---|
+> | `obituaries` | never existed | `obituary` |
+> | `econ` | never existed | `economics` |
+> | `clownworld` | retired from the data | — |
+>
+> Separately, **`bitcoin` is not a tag.** It was retired from every row and now exists only as
+> a `category`, so `/api/events/tags/bitcoin` returns an empty list. See the `category` field
+> above.
+
+The most-used tags, by event count as of 2026-08-10 (English; Russian is within a row or two):
+
+*   `cypherpunks` (118): the cypherpunk movement and its figures — Satoshi Nakamoto, Hal Finney, David Chaum and other early adopters.
+*   `first` (103): milestone events marking a first occurrence in the Bitcoin ecosystem.
+*   `archives` (97): material preserved from primary sources.
+*   `mustread` (66): documents, articles and books deemed essential reading.
+*   `legal` (62): lawsuits, regulations and government legal action.
+*   `privacy` (60): privacy aspects, technologies and discussions.
+*   `satoshi` (60): events concerning Satoshi Nakamoto specifically.
+*   `prebitcoin` (57): events before Bitcoin itself, including its intellectual ancestry.
+*   `security` (52): vulnerabilities, disclosures and defensive practice.
+*   `macro` (49): macroeconomic events and their bearing on Bitcoin.
+*   `obituary` (49): the Bitcoin obituaries.
+*   `software` (46): releases and client software.
+*   `scam` (40): scams, financial losses and theft.
+*   `development` (39): Bitcoin Core releases, protocol upgrades and technical proposals.
+*   `bitcointalk` (37): events and discussions from the BitcoinTalk forum.
+*   `mining` (36): mining, hardware and difficulty.
+*   `cryptography` (35): cryptographic primitives and research.
+*   `media` (32): mentions of Bitcoin in articles, TV and other media.
+*   `price` (27): price action and market milestones.
+*   `finney` (26): Hal Finney specifically.
+
+Also present and self-explanatory: `onchain`, `lightning`, `hack`, `ecash`, `holiday`,
+`trading`, `quotes`, `mtgox`, `silkroad`, `wikileaks`, `freedom`, `protocol`, `bip`,
+`halving`, `hashrate`, `economics`, `shitcoin`, `meme`, `szabo`, `salvador`, `adoption`, and
+roughly 170 more. Call `/api/tags` for the full set.
 
 ## Language Support
 

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -201,7 +201,7 @@ func TestTagsEndpointResponds(t *testing.T) {
 }
 
 // TestTagCountsAgreeWithByTagEndpoint pins the two endpoints together. They
-// disagreed by one for 'bitcoin' because /api/tags counted occurrences while
+// disagreed by one for 'satoshi' because /api/tags counted occurrences while
 // /api/events/tags/:tag counts events, and some events list a tag twice.
 func TestTagCountsAgreeWithByTagEndpoint(t *testing.T) {
 	var body struct {
@@ -222,7 +222,7 @@ func TestTagCountsAgreeWithByTagEndpoint(t *testing.T) {
 }
 
 // TestTagCountsEventsNotOccurrences is the specific case behind that
-// disagreement: fixture event 3 lists "bitcoin" twice.
+// disagreement: fixture event 3 lists "satoshi" twice.
 func TestTagCountsEventsNotOccurrences(t *testing.T) {
 	var body struct {
 		Data []tagInfo `json:"data"`
@@ -230,16 +230,16 @@ func TestTagCountsEventsNotOccurrences(t *testing.T) {
 	get(t, "/api/tags?lang=ru", &body)
 
 	for _, tag := range body.Data {
-		if tag.Tag != "bitcoin" {
+		if tag.Tag != "satoshi" {
 			continue
 		}
 		// Events 2, 3 and 4 carry it; event 3 carries it twice.
 		if tag.Count != 3 {
-			t.Fatalf("bitcoin: want 3 events, got %d — counting occurrences, not events", tag.Count)
+			t.Fatalf("satoshi: want 3 events, got %d — counting occurrences, not events", tag.Count)
 		}
 		return
 	}
-	t.Fatal("bitcoin missing from /api/tags")
+	t.Fatal("satoshi missing from /api/tags")
 }
 
 // TestTagFilterIgnoresLikeWildcards guards a defect that answered a question
@@ -268,7 +268,7 @@ func TestTagFilterIgnoresLikeWildcards(t *testing.T) {
 	// match anything, bug or no bug. An assertion that cannot fail is worse
 	// than no assertion, because it reads like coverage.
 	probes := []struct{ wildcard, literal string }{
-		{"bitcoi_", "bitcoin"}, // _ matches exactly one character
+		{"satosh_", "satoshi"}, // _ matches exactly one character
 		{"_____", "price"},     // five characters, and `price` is five long
 	}
 
@@ -290,14 +290,14 @@ func TestTagFilterIgnoresLikeWildcards(t *testing.T) {
 // the wildcards.
 func TestTagFilterIsCaseInsensitive(t *testing.T) {
 	var lower, upper eventList
-	get(t, "/api/events/tags/bitcoin?lang=ru&limit=1", &lower)
-	get(t, "/api/events/tags/BITCOIN?lang=ru&limit=1", &upper)
+	get(t, "/api/events/tags/satoshi?lang=ru&limit=1", &lower)
+	get(t, "/api/events/tags/SATOSHI?lang=ru&limit=1", &upper)
 
 	if lower.Pagination.Total == 0 {
-		t.Fatal("bitcoin matched nothing")
+		t.Fatal("satoshi matched nothing")
 	}
 	if lower.Pagination.Total != upper.Pagination.Total {
-		t.Errorf("case sensitivity: bitcoin=%d BITCOIN=%d",
+		t.Errorf("case sensitivity: satoshi=%d SATOSHI=%d",
 			lower.Pagination.Total, upper.Pagination.Total)
 	}
 }

--- a/tests/contract_test.go
+++ b/tests/contract_test.go
@@ -241,7 +241,7 @@ func TestPaginationParamsAreRejected(t *testing.T) {
 	// wired up differently, it is this list that says so.
 	paths := []string{
 		"/api/events?lang=ru&",
-		"/api/events/tags/bitcoin?lang=ru&",
+		"/api/events/tags/satoshi?lang=ru&",
 		"/api/search?lang=ru&q=bitcoin&",
 	}
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -258,16 +258,28 @@ func fixtureRows(lang string) []fixtureRow {
 			Media:       strptr(`["https://example.org/whitepaper.png"]`),
 			References:  strptr(`["https://bitcoin.org/bitcoin.pdf"]`),
 			CreatedAt:   strptr("2026-08-08 09:59:56"), UpdatedAt: strptr("2026-08-08 09:59:56"),
-			Tags: `["bitcoin", "mustread"]`, URLPath: "/2008-11-01/bitcoin-whitepaper-published/",
+			Tags: `["satoshi", "mustread"]`, URLPath: "/2008-11-01/bitcoin-whitepaper-published/",
 			Category: "mustread",
 		},
 		{
 			ID: 3, Date: "2013-08-09",
-			Title:       "A duplicated tag lives here",
-			Description: "This row lists bitcoin twice, as four real rows in canonical do.",
+			Title: "A duplicated tag lives here",
+			// Canonical had four such rows when this fixture was written. It has
+			// none today — the 2026-08-10 tag cleanup deduplicated them — so this
+			// row no longer mirrors the data, and that is deliberate.
+			//
+			// It stays because the defect it guards is in the handler, not in the
+			// data: /api/tags counted occurrences while /api/events/tags/:tag
+			// counted events, so the two disagreed by one for any tag listed
+			// twice. Removing the duplicate would leave
+			// TestTagCountsEventsNotOccurrences unable to fail, which is worse
+			// than a fixture that is deliberately harsher than production — a
+			// test that cannot fail reads like coverage while providing none.
+			// Nothing stops canonical reintroducing a duplicate tomorrow.
+			Description: "This row lists satoshi twice; canonical no longer does, but the handler must still count events.",
 			Media:       nil, References: nil,
 			CreatedAt: nil, UpdatedAt: nil,
-			Tags: `["bitcoin", "archives", "bitcoin"]`, URLPath: "/2013-08-09/a-duplicated-tag-lives-here/",
+			Tags: `["satoshi", "archives", "satoshi"]`, URLPath: "/2013-08-09/a-duplicated-tag-lives-here/",
 			Category: "archives",
 		},
 		{
@@ -278,7 +290,7 @@ func fixtureRows(lang string) []fixtureRow {
 			// pair here, TestListOrderBreaksTiesById cannot fail, and a test that
 			// cannot fail reads like coverage while providing none.
 			//
-			// It deliberately carries neither `bitcoin` in its tags nor
+			// It deliberately carries neither `satoshi` in its tags nor
 			// `whitepaper`/`published` in its text: the tag counts and the phrase
 			// search assertions are pinned to exact numbers elsewhere.
 			ID: 5, Date: "2008-11-01",
@@ -299,7 +311,11 @@ func fixtureRows(lang string) []fixtureRow {
 			Description: "Идентификаторы независимы в каждом языке.",
 			Media:       nil, References: nil,
 			CreatedAt: nil, UpdatedAt: nil,
-			Tags: `["bitcoin"]`, URLPath: "/2020-12-08/ru-only/",
+			Tags: `["satoshi"]`, URLPath: "/2020-12-08/ru-only/",
+			// The tag and the category deliberately differ: `bitcoin` is a
+			// category with no corresponding tag anywhere in canonical, which is
+			// precisely the pairing that would break a consumer still deriving
+			// category from tags[0].
 			Category: "bitcoin",
 		})
 	}


### PR DESCRIPTION
Two commits, same root cause as `category`: our own artifacts encode a vocabulary canonical
retired, and nothing had an opinion about the difference.

**docs: the tag list.** Three documented tags matched nothing — `obituaries`, `econ`,
`clownworld` — and a tag with no events is an empty list, not an error, so a client following
the document failed silently. Two have live near-misses (`obituary`, `economics`) that make it
look like the caller's typo. The list also covered 16 of 192 live tags, documenting `adoption`
(3 events) while omitting `archives` (97) and `satoshi` (60).

Rather than curate a longer list that rots the same way, it now points at `GET /api/tags` as
authoritative and keeps a dated, explicitly non-exhaustive top-20 for orientation, plus a
migration table for anyone who hardcoded the dead entries. Every tag and count in the new
section was verified against both artifacts.

**test: the fixture.** It modelled `bitcoin` as a tag on three rows; canonical has none.
Replaced with `satoshi` (60 events, same 7-character shape the LIKE-wildcard probe needs).

The duplicate-tag row is **kept** deliberately, and its comment now says why: canonical
deduplicated those rows on 2026-08-10, but the defect the row guards is in the handler, not the
data. Removing it would leave `TestTagCountsEventsNotOccurrences` unable to fail. Verified the
renamed tests still bite by making the handler count occurrences again — both fail, reporting
4 vs 3.
