### PR TITLE
Filter events by category, and list categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ These are the parts that are not guessable from the endpoint list. Each was a re
     liable to grow** — `security` appeared a day after the column did — so accept unrecognised
     values rather than hardcoding the list. The service derives the accepted values from the
     artifact at startup for that reason; an unknown category is a `400`, not an empty list.
+    It is a filter on `/api/events` **only** — sending it to `/api/search` or
+    `/api/events/tags/:tag` is a `400` too, rather than a `200` full of unfiltered results.
 *   **`events` is always an array**, `[]` when nothing matches, on every endpoint that
     returns a list.
 *   **An unknown `lang` silently serves English.** `lang=xx` is not an error. Do not rely on

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ These are the parts that are not guessable from the endpoint list. Each was a re
     It is a filter on `/api/events` **only** — sending it to `/api/search` or
     `/api/events/tags/:tag` is a `400` too, rather than a `200` full of unfiltered results.
 *   **`events` is always an array**, `[]` when nothing matches, on every endpoint that
-    returns a list.
+    returns a list — and so is `data` on `/api/tags` and `/api/categories`. Never `null`.
 *   **An unknown `lang` silently serves English.** `lang=xx` is not an error. Do not rely on
     a typo being caught.
 *   **`/api/tags` returns its list under `data`**, not `tags`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ These are the parts that are not guessable from the endpoint list. Each was a re
       "path": "/srv/bitcal/data/releases/20260809T095654Z/events_ru.db",
       "sha256": "13748ac7…",
       "rows": 582,
-      "fts": { "indexed": 582, "consistent": true }
+      "fts": { "indexed": 582, "consistent": true },
+      "categories": { "present": true, "count": 15 }
     }
   }
 }
@@ -131,6 +132,13 @@ Those two differing is the failure the endpoint exists to catch.
 
 `fts.consistent` is `indexed == rows`: every event is reachable by search. When it is false,
 `status` becomes `degraded` — the service is up and search is silently incomplete.
+
+`categories` is what the service read out of the artifact at startup, and it is what
+`?category=` validates against. `count: 0` means every category filter is rejected — either
+the artifact predates the column (`present: false`, which is what a rollback looks like) or
+no row carries a value (`present: true`, which should never have been published).
+`publish-db.sh` refuses to leave a release in the second state. It does not affect `status`:
+a rollback target is not a degraded service.
 
 **The service refuses to start** if a full-text index is missing, empty or unreadable. That
 is deliberate: a broken index makes `/api/search` return an empty result set, which is

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ These are the parts that are not guessable from the endpoint list. Each was a re
   "version": "0.1.0-dd9c9dd",
   "databases": {
     "ru": {
-      "path": "/srv/bitcal/data/releases/20260809T095654Z/events_ru.db",
-      "sha256": "13748ac7…",
-      "rows": 582,
-      "fts": { "indexed": 582, "consistent": true },
+      "path": "/srv/bitcal/data/releases/20260810T131954Z/events_ru.db",
+      "sha256": "12a5f040…",
+      "rows": 581,
+      "fts": { "indexed": 581, "consistent": true },
       "categories": { "present": true, "count": 15 }
     }
   }

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ These are the parts that are not guessable from the endpoint list. Each was a re
     website colours and filters by. Consumers used to derive it from the first tag; tag order
     carries no meaning now and that inference is wrong. `bitcoin` is the sharp edge: it is a
     category on 132 RU and 66 EN events and **no longer a tag on any**, so
-    `/api/events/tags/bitcoin` returns an empty list. The set of categories is closed but
-    **owned by the data and liable to grow** — `security` appeared a day after the column did —
-    so accept unrecognised values rather than hardcoding the list. There is no `?category=`
-    filter yet: fetch and filter client-side, or ask for one.
+    `/api/events/tags/bitcoin` returns an empty list. Filter with `/api/events?category=…` and
+    discover the values with `/api/categories`. The set is closed but **owned by the data and
+    liable to grow** — `security` appeared a day after the column did — so accept unrecognised
+    values rather than hardcoding the list. The service derives the accepted values from the
+    artifact at startup for that reason; an unknown category is a `400`, not an empty list.
 *   **`events` is always an array**, `[]` when nothing matches, on every endpoint that
     returns a list.
 *   **An unknown `lang` silently serves English.** `lang=xx` is not an error. Do not rely on

--- a/categories.go
+++ b/categories.go
@@ -101,13 +101,12 @@ func loadCategories(db *gorm.DB) (categorySet, error) {
 		return categorySet{}, fmt.Errorf("reading the category vocabulary: %w", err)
 	}
 
-	// The column exists but carries nothing on any row. That is not a rollback
-	// target, it is an upstream failure of validator invariant 13, and the
-	// handler treats an empty set as "no vocabulary to validate against" and
-	// lets the filter through — which means ?category=anything answers 200 with
-	// an empty list. Left as it was, but note that it is now the only route to
-	// that behaviour: the case this permissiveness was written for, an artifact
-	// predating the column, is handled above and no longer arrives here.
+	// The column may exist and carry nothing on any row. That is not a rollback
+	// target — it is an upstream failure of validator invariant 13 — and it is
+	// still not a reason to refuse to boot: every other endpoint answers
+	// correctly, exactly as on an artifact predating the column. known() rejects
+	// every value in that state, so the filter says so rather than answering 200
+	// with an empty list. The caller is told at warn during boot.
 	set := categorySet{present: true, members: make(map[string]bool, len(values)), sorted: values}
 	for _, v := range values {
 		set.members[v] = true
@@ -117,17 +116,17 @@ func loadCategories(db *gorm.DB) (categorySet, error) {
 
 // known reports whether a category exists in this artifact.
 //
-// An artifact with no category column knows nothing, so every value is
-// rejected: no row can match a column that is not there, and the alternative is
-// the empty list that ?category= exists to avoid. An empty vocabulary on an
-// artifact that does have the column accepts everything: see loadCategories.
+// An artifact with nothing to check against rejects every value, and there are
+// two ways to have nothing: no `category` column at all, or a column no row
+// carries a value in. Both leave members empty, and in both no row can match, so
+// letting the filter through would answer 200 with an empty list — the outcome
+// ?category= validates in order to avoid.
+//
+// An empty vocabulary used to be accepted instead, on the reasoning that there
+// was no vocabulary to validate against. That was written when a missing column
+// was the case that reached here; it is handled separately now, and all the
+// permissiveness did was leave one route back to the silent empty result.
 func (c categorySet) known(v string) bool {
-	if !c.present {
-		return false
-	}
-	if len(c.members) == 0 {
-		return true
-	}
 	return c.members[v]
 }
 
@@ -136,8 +135,8 @@ func (c categorySet) expected() string {
 	if !c.present {
 		return "nothing: this artifact predates the category column, so no value can match"
 	}
-	// Unreachable while known() lets an empty vocabulary through, and kept
-	// anyway so that changing that decision does not also need a message.
+	// The column is there but no row carries a value. known() rejects
+	// everything in that state, so this is what such a caller is told.
 	if len(c.sorted) == 0 {
 		return "nothing: this artifact carries no categories"
 	}

--- a/categories.go
+++ b/categories.go
@@ -18,6 +18,16 @@ const categoryProbeTimeout = 10 * time.Second
 // categorySet is one language's category vocabulary, read out of its artifact
 // at startup.
 type categorySet struct {
+	// present is whether the artifact has a `category` column at all. It is a
+	// different question from whether the vocabulary is empty, and conflating
+	// the two is what made an artifact published before 2026-08-09 a boot
+	// failure: see loadCategories.
+	//
+	// The zero value is false, which is also what a lookup for a language that
+	// was never loaded returns. That is the safe direction — an unknown
+	// language validates against nothing and rejects, rather than accepting
+	// silently, which is the shape the ?lang=xx bug took.
+	present bool
 	// members is the lookup used to validate ?category=. Keys are lowercase.
 	members map[string]bool
 	// sorted preserves a stable order for error messages, so a client is told
@@ -48,9 +58,34 @@ var categoriesByLang = map[string]categorySet{}
 // file descriptor on a specific inode, so the vocabulary cannot drift under it;
 // publish-db.sh restarts the service on every release precisely because that is
 // the only way anything here picks up new data.
+//
+// An artifact that predates the column is not an error. `category` arrived on
+// 2026-08-09, every release before that has no such column, and those files are
+// still on the box as rollback targets — publish-db.sh's rollback() re-points
+// `current` at the previous release and restarts. Treating a missing column as
+// a fatal error made this binary refuse to start against any of them, which
+// turned a rollback into an outage and silently coupled the binary's version to
+// the artifact's. Everything except ?category= works perfectly well on such an
+// artifact, so the service boots, says so at warn, and rejects the one filter it
+// cannot answer.
 func loadCategories(db *gorm.DB) (categorySet, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), categoryProbeTimeout)
 	defer cancel()
+
+	// Asked of the schema rather than inferred from a failed SELECT. Matching
+	// on "no such column" would work today but puts a driver's error text on
+	// the boot path, where a reworded message becomes a service that will not
+	// start; pragma_table_info answers the question directly and is the same
+	// idiom the suite already uses to read an artifact's columns.
+	var hasColumn int64
+	if err := db.WithContext(ctx).Raw(
+		`SELECT count(*) FROM pragma_table_info('events') WHERE name = 'category'`,
+	).Scan(&hasColumn).Error; err != nil {
+		return categorySet{}, fmt.Errorf("checking for the category column: %w", err)
+	}
+	if hasColumn == 0 {
+		return categorySet{}, nil
+	}
 
 	var values []string
 	if err := db.WithContext(ctx).Raw(
@@ -66,35 +101,47 @@ func loadCategories(db *gorm.DB) (categorySet, error) {
 		return categorySet{}, fmt.Errorf("reading the category vocabulary: %w", err)
 	}
 
-	// An artifact with no categories at all is a real possibility — an older
-	// release predating the column would look exactly like this — and it must
-	// not be mistaken for "every category is invalid". The handler treats an
-	// empty set as "no vocabulary to validate against" and lets the filter
-	// through, so this returns cleanly rather than failing the boot: the column
-	// is canonical's invariant to enforce, not this service's to refuse to
-	// start over.
-	set := categorySet{members: make(map[string]bool, len(values)), sorted: values}
+	// The column exists but carries nothing on any row. That is not a rollback
+	// target, it is an upstream failure of validator invariant 13, and the
+	// handler treats an empty set as "no vocabulary to validate against" and
+	// lets the filter through — which means ?category=anything answers 200 with
+	// an empty list. Left as it was, but note that it is now the only route to
+	// that behaviour: the case this permissiveness was written for, an artifact
+	// predating the column, is handled above and no longer arrives here.
+	set := categorySet{present: true, members: make(map[string]bool, len(values)), sorted: values}
 	for _, v := range values {
 		set.members[v] = true
 	}
 	return set, nil
 }
 
-// known reports whether a category exists in this artifact. An empty
-// vocabulary accepts everything: see loadCategories.
+// known reports whether a category exists in this artifact.
+//
+// An artifact with no category column knows nothing, so every value is
+// rejected: no row can match a column that is not there, and the alternative is
+// the empty list that ?category= exists to avoid. An empty vocabulary on an
+// artifact that does have the column accepts everything: see loadCategories.
 func (c categorySet) known(v string) bool {
+	if !c.present {
+		return false
+	}
 	if len(c.members) == 0 {
 		return true
 	}
 	return c.members[v]
 }
 
-// list renders the vocabulary for an error message.
-func (c categorySet) list() string {
+// expected renders what would have been accepted, as badParam's `want` clause.
+func (c categorySet) expected() string {
+	if !c.present {
+		return "nothing: this artifact predates the category column, so no value can match"
+	}
+	// Unreachable while known() lets an empty vocabulary through, and kept
+	// anyway so that changing that decision does not also need a message.
 	if len(c.sorted) == 0 {
-		return "(this artifact carries no categories)"
+		return "nothing: this artifact carries no categories"
 	}
 	s := append([]string(nil), c.sorted...)
 	sort.Strings(s)
-	return strings.Join(s, ", ")
+	return "one of: " + strings.Join(s, ", ")
 }

--- a/categories.go
+++ b/categories.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// categoryProbeTimeout bounds the boot query, for the same reason probeFTS is
+// bounded: a query that hangs here is a boot that hangs, and /api/tags proved
+// this service can hang rather than fail.
+const categoryProbeTimeout = 10 * time.Second
+
+// categorySet is one language's category vocabulary, read out of its artifact
+// at startup.
+type categorySet struct {
+	// members is the lookup used to validate ?category=. Keys are lowercase.
+	members map[string]bool
+	// sorted preserves a stable order for error messages, so a client is told
+	// what it could have asked for rather than only that it was wrong.
+	sorted []string
+}
+
+// categoriesByLang holds the vocabulary per language. Populated once by
+// loadCategories during boot and read-only afterwards, so no lock is needed:
+// the artifact is opened read-only and cannot change under a running process —
+// a release replaces the file and restarts the service.
+var categoriesByLang = map[string]categorySet{}
+
+// loadCategories reads the distinct categories out of an artifact.
+//
+// The vocabulary is derived from the data rather than compiled in, and that is
+// the whole design decision here. `category` is a closed set, but canonical
+// owns it and it grows: the column shipped 2026-08-09 with fourteen values and
+// gained `security` the next day. A hardcoded list would have rejected
+// `security` with a 400 until a new binary was built *and* deployed — turning a
+// content edit into a code release. Reading it at boot means a new category
+// works the moment the artifact carrying it is published, which is the same
+// moment the rows using it appear.
+//
+// The cost is one query per artifact at startup, no DDL, no writes.
+//
+// It is deliberately not refreshed while running. The process holds an open
+// file descriptor on a specific inode, so the vocabulary cannot drift under it;
+// publish-db.sh restarts the service on every release precisely because that is
+// the only way anything here picks up new data.
+func loadCategories(db *gorm.DB) (categorySet, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), categoryProbeTimeout)
+	defer cancel()
+
+	var values []string
+	if err := db.WithContext(ctx).Raw(
+		// TRIM and LOWER defensively: the column is mandatory by validator
+		// invariant 13, not by the DDL, so nothing in the database itself
+		// prevents a stray blank or a capital. Measured clean across both
+		// artifacts on 2026-08-10, and this costs nothing to keep honest.
+		`SELECT DISTINCT LOWER(TRIM(category)) AS category
+		 FROM events
+		 WHERE category IS NOT NULL AND TRIM(category) != ''
+		 ORDER BY category ASC`,
+	).Scan(&values).Error; err != nil {
+		return categorySet{}, fmt.Errorf("reading the category vocabulary: %w", err)
+	}
+
+	// An artifact with no categories at all is a real possibility — an older
+	// release predating the column would look exactly like this — and it must
+	// not be mistaken for "every category is invalid". The handler treats an
+	// empty set as "no vocabulary to validate against" and lets the filter
+	// through, so this returns cleanly rather than failing the boot: the column
+	// is canonical's invariant to enforce, not this service's to refuse to
+	// start over.
+	set := categorySet{members: make(map[string]bool, len(values)), sorted: values}
+	for _, v := range values {
+		set.members[v] = true
+	}
+	return set, nil
+}
+
+// known reports whether a category exists in this artifact. An empty
+// vocabulary accepts everything: see loadCategories.
+func (c categorySet) known(v string) bool {
+	if len(c.members) == 0 {
+		return true
+	}
+	return c.members[v]
+}
+
+// list renders the vocabulary for an error message.
+func (c categorySet) list() string {
+	if len(c.sorted) == 0 {
+		return "(this artifact carries no categories)"
+	}
+	s := append([]string(nil), c.sorted...)
+	sort.Strings(s)
+	return strings.Join(s, ", ")
+}

--- a/deploy/bitcal-api.service
+++ b/deploy/bitcal-api.service
@@ -31,12 +31,16 @@
 #        D=$(ssh root@host "mktemp -d /tmp/bitcal-build.XXXXXX")
 #        git archive --format=tar HEAD | ssh root@host "tar -x -C $D"
 #        ssh root@host "cd $D && PATH=/usr/local/go/bin:\$PATH \
-#                       make build VERSION=0.1.0-\$(git rev-parse --short HEAD)"
+#                       make build VERSION=0.1.0-$(git rev-parse --short HEAD)"
 #
 #      Pass VERSION explicitly. The exported tree has no .git, so the
 #      Makefile's `git rev-parse` fallback yields 0.1.0-unknown — and you find
-#      out from /health afterwards. Go is at /usr/local/go/bin and is not on
-#      root's PATH.
+#      out from /health afterwards. The $( ) around rev-parse is deliberately
+#      NOT escaped, unlike the \$PATH beside it: it must expand on your
+#      machine, where .git exists. Escaped, it runs in the exported tree on
+#      the box and names the version `0.1.0-` — a variant of exactly the
+#      failure this paragraph is about. Go is at /usr/local/go/bin and is not
+#      on root's PATH.
 #
 #   2. Run `make test` in that directory, on the box. The suite is black-box —
 #      it builds the binary, stages a fixture at 0444 in a 0555 directory and

--- a/deploy/publish-api.sh
+++ b/deploy/publish-api.sh
@@ -459,6 +459,22 @@ for lang in sorted(set(b_dbs) & set(a_dbs)):
     if not fts.get("consistent") or fts.get("indexed") != a["rows"]:
         problems.append(f'{lang}: index covers {fts.get("indexed")} of {a["rows"]} rows')
 
+    # The vocabulary is derived from the artifact by the binary, so this is the
+    # one check publish-db.sh cannot make: the data is provably unchanged above,
+    # which means any movement here is the new binary reading the same file
+    # differently. A vocabulary that went to zero would reject every ?category=
+    # while looking healthy in every other field.
+    #
+    # Compared only when both snapshots carry it. Absent on one side is a binary
+    # older than the field on that side — the first deploy of one that has it,
+    # or a rollback past it — and neither is a fault.
+    b_cats, a_cats = b.get("categories"), a.get("categories")
+    if b_cats is not None and a_cats is not None and b_cats != a_cats:
+        problems.append(
+            f'{lang}: the category vocabulary changed across a binary deploy —\n'
+            f'         {b_cats} -> {a_cats}\n'
+            f'         The artifact is byte-identical, so this binary reads it differently.')
+
 print("\n".join(notes))
 if problems:
     print("PROBLEMS", file=sys.stderr)

--- a/deploy/publish-db.sh
+++ b/deploy/publish-db.sh
@@ -7,6 +7,7 @@
 # written, which is why the steps below are in the order they are.
 #
 #   local  preflight  checksums + validate.py + scoped git state
+#   remote preflight  rollback target, disk, and that the box can run the checks
 #   remote stage      copy into releases/<ts>.incoming, verify, permission, rename
 #   remote validate   run validate.py against the STAGED copy, not just the source
 #   local  schema     the API's own test, against the staged copy — see below
@@ -14,7 +15,27 @@
 #   remote verify     /health hashes, FTS coverage, categories, and a search assertion
 #   remote prune      keep the last N releases
 #
-# Any failure after the flip rolls back to the previous release automatically.
+# What happens when something fails after the flip depends on what failed, and
+# the distinction is the point:
+#
+#   the release is bad          roll back, automatically. A service that will
+#                               not come up, a /health that describes a
+#                               different release, a search term that matches
+#                               nothing — the artifact is the problem.
+#   the *check* could not run   do not roll back. An unreachable box or a
+#                               missing jq says nothing about the release, and
+#                               reverting a publish that may be perfectly good
+#                               because the checker broke is the wrong trade.
+#                               The script exits non-zero saying the release is
+#                               live and unverified, and prints the commands to
+#                               check or undo it by hand.
+#
+# It cannot promise more than that: rolling back needs SSH too, so a box that
+# has gone away cannot be rolled back to anything by this or any other script.
+# What it does promise is that it never exits quietly. Preflight checks the
+# tooling the later steps depend on — jq, a service already answering /health —
+# before anything is staged, so the second case is rare: a missing jq is a
+# property of the box, not something that appears halfway through a publish.
 #
 # The restart is not optional. SQLite holds an open file descriptor on the
 # database inode; flipping `current` alone leaves the old file being served,
@@ -62,6 +83,10 @@ KEEP=5
 DRY_RUN=0
 ASSUME_YES=0
 ALLOW_SCHEMA_DRIFT=0
+
+# Read from the box during preflight, and empty when it could not be read — in
+# which case the search assertion is skipped rather than guessed at.
+API_KEY=""
 
 # The repo this script lives in, so the schema guard can find the Go suite
 # regardless of where it was invoked from.
@@ -236,6 +261,40 @@ remote "python3 -c 'import sqlite3' >/dev/null 2>&1" \
 
 # The box has no sqlite3 CLI, which is why every remote database assertion in
 # this script goes through python3 or /health rather than shelling out to it.
+
+# Everything the verify step needs, proved before anything is staged.
+#
+# These are properties of the box, not of the release: jq either is installed or
+# is not, and the service either is answering or is not, and neither changes
+# halfway through a publish. Discovering them here costs nothing — nothing has
+# been copied, no symlink has moved — and the operator gets "install jq on the
+# box" instead of a rolled-back release and a verify step that could not run.
+remote "command -v jq >/dev/null 2>&1" \
+	|| die "jq is not installed on $SSH_HOST, and the search assertion at the end of this
+       script needs it. Install it (apt-get install -y jq) and re-run. Publishing
+       without it would mean flipping the symlink and then discovering that the
+       release cannot be verified."
+
+# Only when something is already being served. On a first publish there is
+# nothing to answer, and requiring it would make the script unable to bootstrap.
+if [ -n "$PREVIOUS_RELEASE" ]; then
+	remote "curl -sf --max-time 5 $HEALTH_URL >/dev/null 2>&1" \
+		|| die "$SERVICE is not answering $HEALTH_URL, so it is unhealthy before this
+       script has touched anything. Fix that first: a rollback needs a service
+       that can come back up, and a verify step needs one that can answer."
+	ok "service answering /health"
+fi
+
+# Read here rather than after the flip for the same reason. It is also the one
+# remote read whose failure used to be indistinguishable from an empty file.
+if ! API_KEY=$(remote "sed -n 's/^API_KEYS=//p' /etc/bitcal/api.env | cut -d, -f1"); then
+	API_KEY=""
+fi
+if [ -z "$API_KEY" ]; then
+	warn "could not read an API key from /etc/bitcal/api.env; the search assertion will be skipped"
+else
+	ok "api key readable, search assertion will run"
+fi
 
 AVAIL_KB=$(remote "df -Pk $REMOTE_DATA | awk 'NR==2 {print \$4}'")
 # Only the files that ship. $SOURCE_DIR also holds superseded/, which is an
@@ -430,6 +489,20 @@ fi
 
 step "Flipping the symlink and restarting"
 
+# Every remote read from here to the end of the script is written as
+# `if ! VAR=$(remote …)`. A bare `VAR=$(remote …)` takes the exit status of the
+# command substitution, so under `set -e` an unreachable box stops the script
+# dead between the flip and any rollback — no message, no rollback, exit 1, and
+# a release left live that nobody checked. Inside an `if` condition the
+# assignment is exempt from `set -e` and the failure can be answered.
+#
+# There is deliberately no `trap … ERR` doing this centrally. It would not fire
+# for any of these sites, because ERR traps do not fire inside `if` conditions
+# or `&&`/`||` chains, which is where every one of them now lives; it would add
+# a second, invisible path into rollback, which is the most destructive thing
+# this script does; and it would need its own guard against rolling back twice
+# when a `die` path has already done it. Explicit at each site is longer and
+# reviewable.
 rollback() {
 	[ -n "$PREVIOUS_RELEASE" ] || {
 		warn "no previous release to roll back to; $SERVICE is left stopped or unhealthy"
@@ -471,7 +544,17 @@ ok "current -> $RELEASE"
 # process that keeps dying — the artifact was rejected. That is the signal the
 # poll below watches for, and it is why this reports a bad release in seconds
 # rather than waiting out the whole timeout.
-RESTARTS_BEFORE=$(remote "systemctl show $SERVICE -p NRestarts --value 2>/dev/null || echo 0")
+if ! RESTARTS_BEFORE=$(remote "systemctl show $SERVICE -p NRestarts --value 2>/dev/null || echo 0"); then
+	# The symlink has moved but nothing has restarted, so the running process
+	# still holds the previous inode and callers are unaffected. Putting the
+	# symlink back is cheap and leaves the box consistent. Carrying on with a
+	# guessed baseline is not: a wrong NRestarts turns the poll below into a
+	# false CRASHLOOP verdict, which rolls back anyway — with a worse story.
+	warn "could not read NRestarts from the box"
+	rollback
+	die "lost the box immediately after the symlink flip; the flip was undone.
+       Nothing had restarted, so nothing was serving the new release yet."
+fi
 
 remote "systemctl restart $SERVICE" || { rollback; die "restart failed"; }
 
@@ -521,7 +604,17 @@ ok "healthy after ${ELAPSED}s"
 
 step "Verifying"
 
-HEALTH=$(remote "curl -s --max-time 10 $HEALTH_URL")
+if ! HEALTH=$(remote "curl -s --max-time 10 $HEALTH_URL"); then
+	# Unlike the search probe below, this one does roll back. /health answered
+	# seconds ago — the wait loop above will not leave this block otherwise — so
+	# a failure now is the service going away after coming up, not a checker
+	# that was never able to run. curl's own failure is included in that: a
+	# refused connection here means nothing is listening.
+	warn "the service stopped answering $HEALTH_URL after reporting healthy"
+	rollback
+	die "the new release came up and then stopped answering. It was rolled back;
+       the rejected release was left at $TARGET for inspection."
+fi
 
 # Parsed locally with python3 — already a hard dependency for validate.py —
 # rather than by piping into a remote jq per field. One round trip, one place
@@ -638,31 +731,88 @@ done
 # Vocabulary assertion. The strongest single end-to-end signal, and the only
 # one here that would catch a tokenizer change: it goes through the real search
 # endpoint rather than /health. Cyrillic is the case that actually breaks.
+#
+# Two failures live here and they are kept apart, because they deserve opposite
+# answers. A term that matches nothing is an answer, and a damning one: the
+# index or the tokenizer is broken for that script, and the release comes back
+# out. A probe that never produced an answer at all — the box unreachable, jq
+# gone, curl dead — is evidence about the box, not about the release, and
+# reverting a publish that may be perfectly good because the checker broke would
+# be the wrong trade. That one exits non-zero with the release left running and
+# the commands to finish by hand.
+#
+# Both used to be the same flag, and before that both used to read as a pass:
+# under `[ "$total" -eq 0 ]` an empty $total errored to false, the elif errored
+# to false too, and control fell through to the ok branch — so a verify whose
+# probe had died printed ok with an empty count.
 step "Vocabulary"
-API_KEY=$(remote "sed -n 's/^API_KEYS=//p' /etc/bitcal/api.env | cut -d, -f1")
-[ -n "$API_KEY" ] || warn "could not read an API key from /etc/bitcal/api.env; skipping the search assertion"
 
-if [ -n "$API_KEY" ]; then
+if [ -z "$API_KEY" ]; then
+	# Reported at preflight, before anything was staged. Repeated here so the
+	# absence of the assertion is visible in the release output too.
+	warn "no API key was readable at preflight; skipping the search assertion"
+else
 	vocab_failed=0
+	probe_broken=0
 	for pair in "ru:$VOCAB_RU_TERM:$VOCAB_RU_LAST" "en:$VOCAB_EN_TERM:$VOCAB_EN_LAST"; do
 		lang=${pair%%:*}; rest=${pair#*:}
 		term=${rest%:*}; last=${rest##*:}
-		total=$(remote "curl -s --max-time 10 -H 'X-API-KEY: $API_KEY' --get \
+		if ! total=$(remote "curl -s --max-time 10 -H 'X-API-KEY: $API_KEY' --get \
 			--data-urlencode 'q=$term' --data-urlencode 'lang=$lang' \
-			'$API_URL/search' | jq -r '.pagination.total // 0'")
-		if [ "$total" -eq 0 ]; then
+			'$API_URL/search' | jq -r '.pagination.total // 0'"); then
+			warn "$lang: could not reach the box to run the search probe"
+			probe_broken=1
+			continue
+		fi
+		case "$total" in
+		'' | *[!0-9]*)
+			# ssh worked and the answer is unusable: jq missing (preflight says
+			# it was there, so it went away mid-publish), curl failing inside
+			# the remote pipeline, or /search answering something that is not
+			# JSON. Same bucket as an unreachable box — we never got an answer.
+			warn "$lang: the search probe returned no usable total (got '$total')"
+			probe_broken=1
+			;;
+		0)
 			warn "$lang: '$term' matched NOTHING (was $last) — the index or the tokenizer is broken for this script"
 			vocab_failed=1
-		elif [ "$total" -ne "$last" ]; then
+			;;
+		"$last")
+			ok "$lang: '$term' -> $total"
+			;;
+		*)
 			upper=$(printf '%s' "$lang" | tr '[:lower:]' '[:upper:]')
 			ok "$lang: '$term' -> $total (was $last; update VOCAB_${upper}_LAST in this script if intended)"
-		else
-			ok "$lang: '$term' -> $total"
-		fi
+			;;
+		esac
 	done
+
+	# A proven-bad index outranks a broken probe: if one language answered zero,
+	# roll back whatever happened to the other.
 	if [ "$vocab_failed" -eq 1 ]; then
 		rollback
 		die "a language returned no search results at all — not publishing this"
+	fi
+
+	if [ "$probe_broken" -eq 1 ]; then
+		warn "the release is LIVE and the search assertion never ran against it"
+		die "could not run the search assertion — the release was NOT rolled back.
+       Everything /health can prove about $RELEASE passed; only the end-to-end
+       search check is missing, and rolling back a release on the strength of a
+       broken checker would be worse than leaving it up unverified.
+
+       Check it by hand once the box is reachable (the key is the first entry
+       in /etc/bitcal/api.env):
+
+         ssh $SSH_HOST \"curl -s -H 'X-API-KEY: <key>' --get \\
+           --data-urlencode 'q=$VOCAB_RU_TERM' --data-urlencode 'lang=ru' \\
+           '$API_URL/search' | jq .pagination.total\"
+
+       Expected around $VOCAB_RU_LAST. If it answers 0, undo the release with:
+
+         ssh $SSH_HOST \"ln -sfn '$PREVIOUS_RELEASE' $REMOTE_DATA/current.new \\
+           && mv -T $REMOTE_DATA/current.new $REMOTE_DATA/current \\
+           && systemctl restart $SERVICE\""
 	fi
 fi
 
@@ -672,7 +822,12 @@ fi
 
 step "Pruning old releases (keeping $KEEP)"
 
-PRUNED=$(remote "bash -s" -- "$REMOTE_DATA" "$KEEP" <<'REMOTE'
+# Housekeeping, after a release that has already passed every assertion. A
+# failure here is not grounds to touch the release: old directories left on
+# disk are a disk-space problem, not a serving problem. It is still said out
+# loud, because the whole point of pruning is that nobody watches disk usage.
+PRUNED=""
+if ! PRUNED=$(remote "bash -s" -- "$REMOTE_DATA" "$KEEP" <<'REMOTE'
 set -euo pipefail
 data="$1"; keep="$2"
 current=$(readlink -f "$data/current")
@@ -690,14 +845,23 @@ for d in "${all[@]:0:$((count - keep))}"; do
 	esac
 done
 REMOTE
-)
-if [ -n "$PRUNED" ]; then
+); then
+	warn "pruning failed; old releases are still on the box and will need clearing by hand:"
+	warn "  ssh $SSH_HOST 'ls -1 $REMOTE_DATA/releases'"
+	warn "the release itself is published and verified — this does not affect what is served"
+	PRUNED=""
+elif [ -n "$PRUNED" ]; then
 	printf '%s\n' "$PRUNED" | sed 's/^/       removed /'
 else
 	ok "nothing to prune"
 fi
 
-REMAINING=$(remote "ls -1 $REMOTE_DATA/releases | wc -l | tr -d ' '")
+# Cosmetic, and the last thing this script does. A box that becomes unreachable
+# between the prune and here has not affected a release that is already live and
+# already verified, so this reports what it knows rather than exiting on it.
+if ! REMAINING=$(remote "ls -1 $REMOTE_DATA/releases | wc -l | tr -d ' '"); then
+	REMAINING="an unknown number of"
+fi
 
 # ---------------------------------------------------------------------------
 

--- a/deploy/publish-db.sh
+++ b/deploy/publish-db.sh
@@ -11,7 +11,7 @@
 #   remote validate   run validate.py against the STAGED copy, not just the source
 #   local  schema     the API's own test, against the staged copy — see below
 #   remote flip       symlink, then restart (mandatory — see below)
-#   remote verify     /health hashes, FTS coverage, and a vocabulary assertion
+#   remote verify     /health hashes, FTS coverage, categories, and a search assertion
 #   remote prune      keep the last N releases
 #
 # Any failure after the flip rolls back to the previous release automatically.
@@ -529,13 +529,27 @@ HEALTH=$(remote "curl -s --max-time 10 $HEALTH_URL")
 #
 # Asserts, in one pass: status is ok; both languages resolve to the release
 # just published (this is the check that catches a missed restart); the hashes
-# the process reports match the checksums that shipped with the artifact; and
-# every row is indexed in both languages.
-if ! VERIFY_OUT=$(python3 - "$TARGET" "$SOURCE_DIR/SHA256SUMS" "$HEALTH" <<'PY'
+# the process reports match the checksums that shipped with the artifact; every
+# row is indexed in both languages; and the category vocabulary is non-empty.
+#
+# The category assertion is here because nothing else can make it. An artifact
+# whose `category` column carries nothing on any row has the right schema, so
+# the schema guard passes it; validate.py's invariant 13 is what should have
+# caught it upstream, and if that has failed there is no second opinion. The API
+# rejects every ?category= against such an artifact — correctly, since nothing
+# can match — which means publishing one breaks every client's category filter
+# in a way that only shows up as 400s in someone else's logs. The service says
+# so once in its boot log, which no release reads. /health carries it so this
+# does.
+#
+# Lines prefixed with ! are warnings rather than failures; see the dispatch
+# below.
+if ! VERIFY_OUT=$(python3 - "$TARGET" "$SOURCE_DIR/SHA256SUMS" "$HEALTH" "$ALLOW_SCHEMA_DRIFT" <<'PY'
 import json, sys, pathlib
 
 target, sums_path = sys.argv[1], sys.argv[2]
 health = json.loads(sys.argv[3])
+allow_schema_drift = sys.argv[4] == "1"
 
 published = {}
 for line in pathlib.Path(sums_path).read_text().splitlines():
@@ -573,6 +587,34 @@ for lang in ("en", "ru"):
     else:
         notes.append(f'{lang}: {db["rows"]} rows, all indexed, sha256 matches')
 
+    # Absent, rather than empty, when the running binary predates the field.
+    # That is not a reason to fail a publish and roll back: the binary and the
+    # artifact are released by two different scripts on purpose, so a data
+    # release against an older binary is an ordinary state of the world. It is
+    # said out loud so that a silently skipped check cannot read as a passing
+    # one.
+    cats = db.get("categories")
+    if cats is None:
+        notes.append(f"!{lang}: /health carries no category vocabulary; the running binary "
+                     f"predates the field, so this release is not checked for one")
+    elif not cats.get("present"):
+        # No column at all: the artifact is older than 2026-08-09. The schema
+        # guard should already have refused it, so reaching here means it was
+        # bypassed, and --allow-schema-drift is exactly that bypass.
+        msg = (f"{lang}: the published artifact has no `category` column, so ?category= is "
+               f"rejected for every value and /api/categories is empty")
+        (notes.append("!" + msg) if allow_schema_drift else problems.append(msg))
+    elif not cats.get("count"):
+        # The column is there and every row is NULL or blank. No schema check
+        # can see this, and --allow-schema-drift does not cover it: that flag is
+        # for data the API cannot yet express, not for data that is not there.
+        problems.append(
+            f"{lang}: the `category` column carries no values on any of {db['rows']} rows.\n"
+            f"         validate.py invariant 13 says every row has one, so this artifact\n"
+            f"         should not exist. Every ?category= will be rejected until it is fixed.")
+    else:
+        notes.append(f'{lang}: {cats["count"]} categories')
+
 print("\n".join(notes))
 if problems:
     print("PROBLEMS", file=sys.stderr)
@@ -585,7 +627,13 @@ PY
 	rollback
 	die "/health does not describe the release that was just published"
 fi
-printf '%s\n' "$VERIFY_OUT" | while IFS= read -r line; do [ -n "$line" ] && ok "$line"; done
+printf '%s\n' "$VERIFY_OUT" | while IFS= read -r line; do
+	case "$line" in
+		"") continue ;;
+		"!"*) warn "${line#!}" ;;
+		*) ok "$line" ;;
+	esac
+done
 
 # Vocabulary assertion. The strongest single end-to-end signal, and the only
 # one here that would catch a tokenizer change: it goes through the real search

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -472,11 +472,11 @@ Error responses will typically be in JSON format, like:
           "data": [
             {
               "category": "archives",
-              "count": 83
+              "count": 89
             },
             {
               "category": "bitcoin",
-              "count": 132
+              "count": 66
             }
             // ... more categories
           ]

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -232,7 +232,9 @@ would again be a `200` and an empty list.
 
 `category` is a filter on `/events` only. Sending it to `/search` or `/events/tags/:tag` is a
 `400` rather than being quietly dropped: those endpoints do not narrow by category, and a
-`200` full of unfiltered results is indistinguishable from a filter that ran.
+`200` full of unfiltered results is indistinguishable from a filter that ran. (`/events/:id`
+ignores it, like any other stray parameter: a single-event fetch is not a list a filter could
+narrow, and the response shows the event's real `category`.)
 
 **Search expressions.** `q` is passed to SQLite's FTS5 parser, which rejects bare operators
 (`AND`, `OR`, `NOT`), unbalanced parentheses or quotes, and a leading `*`. These are things a
@@ -574,17 +576,17 @@ Error responses will typically be in JSON format, like:
       "version": "0.1.0-abc1234",
       "databases": {
         "en": {
-          "path": "/srv/bitcal/data/releases/20260809T084800Z/events_en.db",
-          "sha256": "cb95ad42a181aff3f2cf0579ee3f0d647b81db38c8f3228e1d0483fd69a845f2",
+          "path": "/srv/bitcal/data/releases/20260810T131954Z/events_en.db",
+          "sha256": "6abda1c576b81220538b35d2d697064ac5a0ea72ecc6772d9c58832cdcf8f80e",
           "rows": 565,
           "fts": { "indexed": 565, "consistent": true },
           "categories": { "present": true, "count": 15 }
         },
         "ru": {
-          "path": "/srv/bitcal/data/releases/20260809T084800Z/events_ru.db",
-          "sha256": "b2bf2c80054f20dd47d633144d62a5edc46e2184884756fa8719325e1b42581a",
-          "rows": 582,
-          "fts": { "indexed": 582, "consistent": true },
+          "path": "/srv/bitcal/data/releases/20260810T131954Z/events_ru.db",
+          "sha256": "12a5f04093e31ceb0a34cf44b60f4d5758869c96e990bb5b840ac3f983b45ba4",
+          "rows": 581,
+          "fts": { "indexed": 581, "consistent": true },
           "categories": { "present": true, "count": 15 }
         }
       }

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -230,6 +230,10 @@ carries a value — then **every** `category` value is rejected and `/api/catego
 The message says which of the two it is. Nothing can match in either case, so the alternative
 would again be a `200` and an empty list.
 
+`category` is a filter on `/events` only. Sending it to `/search` or `/events/tags/:tag` is a
+`400` rather than being quietly dropped: those endpoints do not narrow by category, and a
+`200` full of unfiltered results is indistinguishable from a filter that ran.
+
 **Search expressions.** `q` is passed to SQLite's FTS5 parser, which rejects bare operators
 (`AND`, `OR`, `NOT`), unbalanced parentheses or quotes, and a leading `*`. These are things a
 person can reasonably type into a search box, so they are client errors, not server errors.
@@ -333,6 +337,7 @@ Error responses will typically be in JSON format, like:
     *   `page` (optional, integer): The page number to retrieve. `1`–`1000000`, defaults to `1`. Out of range or unparseable is a `400`.
     *   `limit` (optional, integer): The number of events per page. `1`–`1000`, defaults to `20`. Out of range or unparseable is a `400` — it is not clamped.
     *   `lang` (optional, string): Language for the events. `en` for English (default), `ru` for Russian.
+    *   `category`: **not supported here** — sending it is a `400`, not a silently unfiltered result. Search does not narrow by category; put the term in `q`, or filter on `/events`.
 *   **Request Body:** None
 *   **Success Response (200 OK):**
     *   **Content-Type:** `application/json`
@@ -506,6 +511,7 @@ Error responses will typically be in JSON format, like:
     *   `page` (optional, integer): The page number to retrieve. `1`–`1000000`, defaults to `1`. Out of range or unparseable is a `400`.
     *   `limit` (optional, integer): The number of events per page. `1`–`1000`, defaults to `20`. Out of range or unparseable is a `400` — it is not clamped.
     *   `lang` (optional, string): Language for the events. `en` for English (default), `ru` for Russian.
+    *   `category`: **not supported here** — sending it is a `400`. This endpoint filters by tag only. `category` and `tags` are different fields, so there is no equivalent to narrowing one by the other; filter by category on `/events` instead.
 *   **Request Body:** None
 *   **Success Response (200 OK):**
     *   **Content-Type:** `application/json`

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -56,10 +56,11 @@ idle.
 
 The API provides the following main functionalities:
 
-*   **`/events`**: Retrieve a paginated list of all events, with powerful filtering by date (year, month, day, or combinations) and language.
+*   **`/events`**: Retrieve a paginated list of all events, with powerful filtering by date (year, month, day, or combinations), category, and language.
 *   **`/events/:id`**: Fetch a single event by its unique ID.
 *   **`/search`**: Perform a full-text search across event titles, descriptions, and tags.
 *   **`/tags`**: Get a list of all unique event tags and their usage counts.
+*   **`/categories`**: Get every category and its event count — what a client needs to build a category filter.
 *   **`/events/tags/:tag`**: Retrieve a paginated list of events associated with a specific tag.
 *   **`/health`**: Report which database artifact the service has open. **Not** under `/api`, and needs no API key.
 
@@ -192,7 +193,7 @@ Standard HTTP status codes are used. Common error responses include:
 
 ### Rejected input
 
-Three classes of input are answered `400` rather than being quietly absorbed, because in each
+Four classes of input are answered `400` rather than being quietly absorbed, because in each
 case the alternative response is indistinguishable from a legitimate result:
 
 **Date filters.** `month`, `day` and `year` must be plain integers in range (`1`–`12`,
@@ -211,6 +212,18 @@ page-size discipline: 1000 is above the corpus, so `limit=1000` legitimately ret
 event for a language in one response. It exists because without any bound `limit=100000` is
 accepted as readily as `limit=20`, and nothing in the response then says the endpoint is
 paginated at all.
+
+**Category.** `category` must be one the artifact actually carries. An unknown value is
+rejected with a message naming the accepted set, rather than returning `200` with an empty
+list — which would be indistinguishable from a category that genuinely has no events, so a
+client could not tell its own typo from a quiet corner of the corpus. Matching is
+case-insensitive.
+
+The accepted set is **read from the artifact when the service starts**, not compiled into the
+binary. That is deliberate: canonical owns this vocabulary and it grows — `security` was added
+on 2026-08-10 — and a hardcoded list would reject a valid new category until a new binary was
+built *and* deployed, turning a content edit into a code release. Call `/api/categories` for
+the current set.
 
 **Search expressions.** `q` is passed to SQLite's FTS5 parser, which rejects bare operators
 (`AND`, `OR`, `NOT`), unbalanced parentheses or quotes, and a leading `*`. These are things a
@@ -239,6 +252,7 @@ Error responses will typically be in JSON format, like:
     *   `year` (optional, string, format: `YYYY` e.g., "2022"): Year for filtering events.
     *   `month` (optional, string, format: `MM` or `M` e.g., "05" or "5"): Month for filtering events.
     *   `day` (optional, string, format: `DD` or `D` e.g., "27" or "7"): Day for filtering events.
+    *   `category` (optional, string): Return only events with this category. Case-insensitive. **An unrecognised value is a `400`**, not an empty list — see *Rejected input*. Combines with the date filters (they AND together), so `?category=bitcoin&month=5` is "bitcoin events in May". Call `/api/categories` for the valid values and their counts; the service derives them from the artifact at startup, so a category canonical adds is accepted as soon as its data is published.
 *   **Request Body:** None
 *   **Success Response (200 OK):**
     *   **Content-Type:** `application/json`
@@ -406,19 +420,23 @@ Error responses will typically be in JSON format, like:
     *   **Body:**
         ```json
         {
-          "data": [ // Note: This endpoint's response structure was not specified as changed, keeping "data" wrapper for now.
+          "data": [
             {
               "tag": "adoption",
-              "count": 72
+              "count": 3
             },
             {
-              "tag": "bitcoin",
-              "count": 1
+              "tag": "archives",
+              "count": 97
             }
-            // ... more tags
+            // ... 190 more tags
           ]
         }
         ```
+
+    Counts are **events, not occurrences**: a row listing the same tag twice counts once, and
+    this number always equals `pagination.total` from `/events/tags/:tag`.
+
 *   **Example:**
     ```bash
     # Get English tags
@@ -428,7 +446,51 @@ Error responses will typically be in JSON format, like:
     curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/tags?lang=ru"
     ```
 
-### 5. Get Events by Tag (Paginated)
+### 5. Get All Categories
+
+*   **Endpoint:** `/categories`
+*   **Method:** `GET`
+*   **Description:** Every category present in the language's artifact, with the number of events carrying it, alphabetically. This is what a client needs to build a category filter without fetching every event to discover what exists — and it is the authoritative list, read from the data rather than from any document.
+*   **Query Parameters:**
+    *   `lang` (optional, string): Language for the categories. `en` for English (default), `ru` for Russian.
+*   **Request Body:** None
+*   **Success Response (200 OK):**
+    *   **Content-Type:** `application/json`
+    *   **Body:**
+        ```json
+        {
+          "data": [
+            {
+              "category": "archives",
+              "count": 83
+            },
+            {
+              "category": "bitcoin",
+              "count": 132
+            }
+            // ... more categories
+          ]
+        }
+        ```
+
+    Unlike `tags`, every event has **exactly one** category, so these counts sum to the total
+    number of events and always equal `pagination.total` from `/events?category=`.
+
+    The two languages carry the same set of category *names* but different counts, and they
+    disagree about the category of 62 of the 562 events they share by `url_path`. That is
+    catalogued upstream and is data, not a bug — a two-language filter will return genuinely
+    different sets for those events.
+
+*   **Example:**
+    ```bash
+    # Get English categories
+    curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/categories?lang=en"
+
+    # Then filter by one
+    curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/events?lang=en&category=bitcoin&limit=5"
+    ```
+
+### 6. Get Events by Tag (Paginated)
 
 *   **Endpoint:** `/events/tags/:tag`
 *   **Method:** `GET`
@@ -483,7 +545,7 @@ Error responses will typically be in JSON format, like:
     curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/events/tags/adoption?limit=2&lang=ru"
     ```
 
-### 6. Health
+### 7. Health
 
 *   **Endpoint:** `/health` — note this is at the root, **not** under `/api`
 *   **Method:** `GET`

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -225,6 +225,11 @@ on 2026-08-10 — and a hardcoded list would reject a valid new category until a
 built *and* deployed, turning a content edit into a code release. Call `/api/categories` for
 the current set.
 
+If the artifact being served has no categories at all — it predates the column, or no row
+carries a value — then **every** `category` value is rejected and `/api/categories` is empty.
+The message says which of the two it is. Nothing can match in either case, so the alternative
+would again be a `200` and an empty list.
+
 **Search expressions.** `q` is passed to SQLite's FTS5 parser, which rejects bare operators
 (`AND`, `OR`, `NOT`), unbalanced parentheses or quotes, and a leading `*`. These are things a
 person can reasonably type into a search box, so they are client errors, not server errors.

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -577,13 +577,15 @@ Error responses will typically be in JSON format, like:
           "path": "/srv/bitcal/data/releases/20260809T084800Z/events_en.db",
           "sha256": "cb95ad42a181aff3f2cf0579ee3f0d647b81db38c8f3228e1d0483fd69a845f2",
           "rows": 565,
-          "fts": { "indexed": 565, "consistent": true }
+          "fts": { "indexed": 565, "consistent": true },
+          "categories": { "present": true, "count": 15 }
         },
         "ru": {
           "path": "/srv/bitcal/data/releases/20260809T084800Z/events_ru.db",
           "sha256": "b2bf2c80054f20dd47d633144d62a5edc46e2184884756fa8719325e1b42581a",
           "rows": 582,
-          "fts": { "indexed": 582, "consistent": true }
+          "fts": { "indexed": 582, "consistent": true },
+          "categories": { "present": true, "count": 15 }
         }
       }
     }
@@ -600,6 +602,15 @@ Error responses will typically be in JSON format, like:
 | `rows` | Rows in `events`. |
 | `fts.indexed` | Documents in the full-text index, read from `events_fts_docsize`. |
 | `fts.consistent` | `fts.indexed == rows` — every event is reachable by `/api/search`. |
+| `categories.present` | Whether the artifact has a `category` column at all. `false` means it predates 2026-08-09. |
+| `categories.count` | Distinct categories the service read from it at startup — the exact set `?category=` validates against, and the same list `/api/categories` returns. |
+
+`categories` is the one part of this document that describes the artifact's *contents* rather
+than its shape, and it is here for the release check: when `count` is `0`, every `?category=`
+is rejected and `/api/categories` is empty, and nothing else outside the boot log says so.
+The two fields are separate because they mean different things — `present: false` is an
+artifact older than the column, which is a legitimate rollback target; `present: true` with
+`count: 0` is a column no row carries a value in, which should never have been published.
 
 #### On the status code
 
@@ -607,6 +618,11 @@ Error responses will typically be in JSON format, like:
 `degraded`. A degraded process is answering every endpoint correctly except for the
 completeness of search, and returning a failure code would have a load balancer pull it for
 no good reason. **Read the `status` field, not the HTTP code.**
+
+`status` reports full-text coverage only. An absent or empty category vocabulary does **not**
+make it `degraded`: serving an artifact that predates the column is what a rollback looks
+like, and a dashboard alarming for the duration of one is pressure to end the rollback rather
+than to fix the release. Read `categories` for that.
 
 The states that would make search useless rather than incomplete — the index missing, empty,
 or unreadable — are not reported here at all, because the service refuses to start on them.

--- a/docs/DatabaseDocumentation.md
+++ b/docs/DatabaseDocumentation.md
@@ -72,7 +72,7 @@ tag order no longer carries meaning and that inference is now wrong. `bitcoin` i
 case — it exists as a category (132 RU, 66 EN) and **no longer exists as a tag at all**, so a
 hard-coded `tag=bitcoin` query returns zero rows.
 
-The two languages disagree about the category of 62 of the 500 events they share by
+The two languages disagree about the category of 62 of the 562 events they share by
 `url_path`. That is catalogued in canonical's README and is data, not a bug — but a
 two-language filter built on this column will return genuinely different sets.
 
@@ -107,7 +107,7 @@ read-only and **cannot create the index**; that would be a change to canonical.
 ## Full-text search: `events_fts`
 
 Both databases carry an FTS5 index and its three triggers. **Both are fully populated**
-(RU 582/582, EN 565/565).
+(RU 581/581, EN 565/565).
 
 ```sql
 CREATE VIRTUAL TABLE events_fts USING fts5(

--- a/docs/DatabaseDocumentation.md
+++ b/docs/DatabaseDocumentation.md
@@ -62,9 +62,10 @@ Present in both database files, with identical definitions.
 **Do not treat that list, or its length, as fixed.** It has already changed twice: the column
 arrived on 2026-08-09 with fourteen values, and `security` was added on 2026-08-10, carved out
 of `bitcoin` (which fell 148→132 RU and 82→66 EN). Canonical owns this vocabulary. Anything
-here that needs the current set should read it from the artifact rather than carry a copy —
-which is also why a future `?category=` filter should derive its accepted values at boot
-instead of hardcoding them, or a fifteenth category would 400 until a new binary shipped.
+here that needs the current set should read it from the artifact rather than carry a copy.
+That is what the API does: `loadCategories` in `categories.go` runs one `SELECT DISTINCT` per
+artifact at startup, and `?category=` validates against the result. Had the list been compiled
+in, `security` would have been rejected as invalid until a new binary was built and deployed.
 
 It replaces an older convention in which consumers read the classification out of `tags[0]`;
 tag order no longer carries meaning and that inference is now wrong. `bitcoin` is the clearest

--- a/health.go
+++ b/health.go
@@ -18,10 +18,29 @@ var version = "dev"
 
 // DatabaseHealth describes one artifact as this process actually has it open.
 type DatabaseHealth struct {
-	Path   string    `json:"path"`
-	SHA256 string    `json:"sha256"`
-	Rows   int64     `json:"rows"`
-	FTS    FTSHealth `json:"fts"`
+	Path       string         `json:"path"`
+	SHA256     string         `json:"sha256"`
+	Rows       int64          `json:"rows"`
+	FTS        FTSHealth      `json:"fts"`
+	Categories CategoryHealth `json:"categories"`
+}
+
+// CategoryHealth reports the category vocabulary this process is serving.
+//
+// Present and Count are separate because they fail for different reasons and
+// call for different responses. Present false is an artifact older than the
+// column — a rollback target, expected to be served that way. Present with
+// Count zero is an artifact whose column carries nothing on any row, which is
+// validator invariant 13 broken upstream and should never have been published.
+// Both reject every ?category=, so a single number would leave the release
+// check unable to say which had happened.
+//
+// It is here because ?category= is the one part of the service whose behaviour
+// depends on the artifact's contents rather than its shape, and nothing else
+// reports that. The boot log says it once; publish-db.sh reads /health.
+type CategoryHealth struct {
+	Present bool `json:"present"`
+	Count   int  `json:"count"`
 }
 
 // HealthResponse is a cross-repo contract: the publisher asserts against it
@@ -32,6 +51,14 @@ type DatabaseHealth struct {
 // way: a degraded service is still serving, and returning a failure code would
 // have a load balancer pull a process that is answering correctly for
 // everything except the completeness of search. Read the field, not the code.
+//
+// An absent or empty category vocabulary deliberately does *not* set
+// "degraded". An artifact predating the column is a rollback target and serving
+// one is a correct outcome, not an incident; marking it degraded would have
+// every dashboard alarm for as long as a rollback was in place, which is the
+// pressure that turns a rollback back into an outage. The condition is reported
+// per database under Categories instead, where publish-db.sh — which knows
+// whether it is publishing or rolling back — can decide what it means.
 type HealthResponse struct {
 	Status    string                    `json:"status"`
 	Version   string                    `json:"version"`
@@ -89,11 +116,23 @@ func buildHealthSnapshot(dbs map[string]struct {
 			snapshot.Status = statusDegraded
 		}
 
+		// Read from what loadCategories put in categoriesByLang rather than
+		// queried again here, so /health cannot report a vocabulary the filter
+		// is not the one validating against. That makes this dependent on
+		// loadCategories having run, which it has: main() loads the vocabulary
+		// before it builds this snapshot, and a missing entry reports the same
+		// zero value an artifact with no column does — the safe direction.
+		vocab := categoriesByLang[lang]
+
 		snapshot.Databases[lang] = DatabaseHealth{
 			Path:   resolved,
 			SHA256: sum,
 			Rows:   rows,
 			FTS:    fts,
+			Categories: CategoryHealth{
+				Present: vocab.present,
+				Count:   len(vocab.sorted),
+			},
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,9 +52,27 @@ const (
 var DB_EN *gorm.DB
 var DB_RU *gorm.DB
 
+// resolveLang maps whatever the caller sent to the language that will actually
+// serve the request. An unrecognised value falls back to English, which is
+// documented behaviour — `lang=xx` is not an error.
+//
+// Anything keyed by language must resolve through this rather than use the raw
+// query parameter, or it ends up describing a different artifact than the one
+// being read. That is not hypothetical: ?category= first validated against
+// categoriesByLang[<raw lang>], so `?lang=xx&category=nonesuch` found no
+// vocabulary to check against, accepted the value, queried the English database
+// and answered 200 with an empty list — reintroducing, for one spelling of one
+// parameter, exactly the silent-empty-result the 400 exists to prevent.
+func resolveLang(langCode string) string {
+	if strings.ToLower(langCode) == "ru" {
+		return "ru"
+	}
+	return "en"
+}
+
 // Helper function to get the correct DB instance based on language
 func getDBInstance(langCode string) *gorm.DB {
-	if strings.ToLower(langCode) == "ru" {
+	if resolveLang(langCode) == "ru" {
 		return DB_RU
 	}
 	return DB_EN // Default to English
@@ -521,8 +539,11 @@ func getAllEventsHandler(c *fiber.Ctx) error {
 	// way in because every stored value is lowercase.
 	if categoryStr := c.Query("category"); categoryStr != "" {
 		want := strings.ToLower(strings.TrimSpace(categoryStr))
-		if !categoriesByLang[lang].known(want) {
-			return badParam(c, "category", categoryStr, "one of: "+categoriesByLang[lang].list())
+		// resolveLang, not the raw parameter: the vocabulary consulted must be
+		// the one belonging to the artifact this request will actually read.
+		vocab := categoriesByLang[resolveLang(lang)]
+		if !vocab.known(want) {
+			return badParam(c, "category", categoryStr, "one of: "+vocab.list())
 		}
 		// LOWER on the column, not a bare equality: the closed set is enforced
 		// by the publisher rather than by the schema, so this must not depend

--- a/main.go
+++ b/main.go
@@ -118,11 +118,16 @@ func badParam(c *fiber.Ctx, name, got, want string) error {
 // helper that returned its error would look like it had refused while the
 // handler carried on and overwrote the body under a 400 status line.
 //
-// Only /api/events honours the parameter. The other two endpoints that return
-// events accepted it and ignored it: a client narrowing a search with
-// &category=bitcoin got every match, with a 200 and nothing anywhere in the
-// response to say the filter had not been applied. That is the same silence the
-// 400 on an unknown category exists to break, arrived at from the other side.
+// Only /api/events honours the parameter. The two list endpoints this guards —
+// /api/search and /api/events/tags/:tag — accepted it and ignored it: a client
+// narrowing a search with &category=bitcoin got every match, with a 200 and
+// nothing anywhere in the response to say the filter had not been applied. That
+// is the same silence the 400 on an unknown category exists to break, arrived
+// at from the other side.
+//
+// /api/events/:id also ignores the parameter and is deliberately not guarded:
+// a fetch by id is not a list a filter could narrow, and the response carries
+// the event's actual category, so nothing about ignoring it is silent.
 //
 // This deliberately does not become a rule about unknown parameters in general.
 // A stray ?foo= carries no expectation that anything will happen; `category` is
@@ -164,8 +169,8 @@ const (
 	defaultLimit = 20
 
 	// maxLimit caps one response. It is a backstop against absurd values rather
-	// than a page-size discipline: at 1000 it sits above the corpus — 582 rows
-	// in the larger language — so a caller who asks for it gets everything in
+	// than a page-size discipline: at 1000 it sits above the corpus — under 600
+	// rows in either language — so a caller who asks for it gets everything in
 	// one body, and only a limit that could not be meant seriously is refused.
 	// The bound still matters, because without one limit=100000 is accepted as
 	// readily as limit=20 and nothing in the response says the endpoint is

--- a/main.go
+++ b/main.go
@@ -326,7 +326,19 @@ func getCategoriesHandler(c *fiber.Ctx) error {
 
 	zlog.Info().Str("lang", lang).Msg("getCategoriesHandler called")
 
-	var result []CategoryInfo
+	// An artifact predating the category column has nothing to report, and the
+	// statement below would fail against it with `no such column`. Answering the
+	// empty list is the truth — this artifact carries no categories — and a 500
+	// on an endpoint the service can perfectly well answer is not.
+	if !categoriesByLang[resolveLang(lang)].present {
+		return c.JSON(fiber.Map{"data": []CategoryInfo{}})
+	}
+
+	// Initialised, not declared nil, for the reason ftsSearchHandler spells out:
+	// Raw().Scan() leaves the slice nil when nothing matches and a nil slice
+	// marshals to JSON null, so a caller would get null from one branch of this
+	// handler and [] from the other.
+	result := []CategoryInfo{}
 	// NOTHING MAY FOLLOW THE FINAL SEMICOLON — see getTagsHandler for what a
 	// trailing comment does to this driver. It is not a style rule.
 	sqlQuery := `
@@ -543,7 +555,7 @@ func getAllEventsHandler(c *fiber.Ctx) error {
 		// the one belonging to the artifact this request will actually read.
 		vocab := categoriesByLang[resolveLang(lang)]
 		if !vocab.known(want) {
-			return badParam(c, "category", categoryStr, "one of: "+vocab.list())
+			return badParam(c, "category", categoryStr, vocab.expected())
 		}
 		// LOWER on the column, not a bare equality: the closed set is enforced
 		// by the publisher rather than by the schema, so this must not depend
@@ -633,7 +645,25 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		return queryFailed(c, err, "Failed to count search results")
 	}
 
-	searchSQL := `
+	// The one column in the list below that an artifact may genuinely not have.
+	// A release predating 2026-08-09 has no `category`, and those files are
+	// rollback targets — so naming it unconditionally makes every search on a
+	// rolled-back artifact answer 500, which is the outage the boot path was
+	// just taught not to cause. Every other handler adapts for free: GORM builds
+	// its SELECT from the struct against the table it can see, and only this
+	// statement enumerates by hand.
+	//
+	// Spliced rather than parameterised because a column name is not a bind
+	// parameter. The value is one of two literals decided here, never anything a
+	// caller sent. Sprintf is safe on this statement specifically because it
+	// contains no other %% verb; anything added below that needs one must escape
+	// it or this stops being a formatting string.
+	categoryCol := " e.category,"
+	if !categoriesByLang[resolveLang(lang)].present {
+		categoryCol = ""
+	}
+
+	searchSQL := fmt.Sprintf(`
 		-- "references" is a SQL reserved word: unquoted, SQLite refuses to
 		-- parse the statement and every search returns 500.
 		--
@@ -652,7 +682,7 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		-- exist. Exposing rank as JSON would be a new contract decision: the
 		-- value is FTS5-internal, negative, and incomparable across queries.
 		SELECT e.id, e.date, e.title, e.description, e.tags, e.media, e."references",
-		       e.url_path, e.category, e.created_at, e.updated_at
+		       e.url_path,%s e.created_at, e.updated_at
 		FROM events e
 		JOIN events_fts fts ON e.id = fts.rowid
 		WHERE events_fts MATCH ?
@@ -662,7 +692,7 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		-- event twice and never shown another.
 		ORDER BY fts.rank, e.id DESC
 		LIMIT ? OFFSET ?;
-	`
+	`, categoryCol)
 	if err := db.Raw(searchSQL, query, limit, offset).Scan(&events).Error; err != nil {
 		if isFTSSyntaxError(err) {
 			return badSearchQuery(c, query, lang, err)
@@ -745,12 +775,23 @@ func main() {
 	// Read from the artifacts rather than compiled in, so a category canonical
 	// adds works as soon as its data is published rather than after a rebuild
 	// and a deploy. See loadCategories.
+	//
+	// An artifact predating the column is not fatal — it is a rollback target,
+	// and refusing to start against one turns a rollback into an outage. It is
+	// logged at warn because it does degrade the service, and only ?category=
+	// and /api/categories are affected.
 	for lang, db := range map[string]*gorm.DB{"en": DB_EN, "ru": DB_RU} {
 		set, err := loadCategories(db)
 		if err != nil {
 			zlog.Fatal().Str("lang", lang).Err(err).Msg("Failed to read the category vocabulary")
 		}
 		categoriesByLang[lang] = set
+		if !set.present {
+			zlog.Warn().Str("lang", lang).
+				Msg("This artifact has no category column: it predates 2026-08-09. " +
+					"?category= will be rejected and /api/categories will be empty")
+			continue
+		}
 		zlog.Info().Str("lang", lang).Int("categories", len(set.sorted)).Msg("Category vocabulary loaded")
 	}
 

--- a/main.go
+++ b/main.go
@@ -405,7 +405,13 @@ func getTagsHandler(c *fiber.Ctx) error {
 
 	zlog.Info().Str("lang", lang).Msg("getTagsHandler called")
 
-	var result []TagInfo
+	// Initialised, not declared nil, for the reason spelled out in
+	// ftsSearchHandler: Raw().Scan() leaves the slice nil when nothing matches
+	// and a nil slice marshals to JSON null, so a caller would have to
+	// special-case one endpoint. /api/categories was written this way from the
+	// start; this one is its sibling and must not answer in a different shape.
+	// Reachable only on an artifact where no row carries a usable tag.
+	result := []TagInfo{}
 	// SQL query to extract, count, and lowercase tags directly from JSON arrays in the 'tags' column.
 	// This approach assumes tags are stored as valid JSON arrays (e.g., ["tag1", "tag2"]).
 	// It replaces the previous Go-based parsing and aggregation logic.

--- a/main.go
+++ b/main.go
@@ -112,6 +112,41 @@ func badParam(c *fiber.Ctx, name, got, want string) error {
 	})
 }
 
+// categoryParamRejected refuses ?category= on an endpoint that does not filter
+// by it, and reports whether it answered the request — the same shape as
+// pagination(), and for the same reason: c.JSON returns nil on success, so a
+// helper that returned its error would look like it had refused while the
+// handler carried on and overwrote the body under a 400 status line.
+//
+// Only /api/events honours the parameter. The other two endpoints that return
+// events accepted it and ignored it: a client narrowing a search with
+// &category=bitcoin got every match, with a 200 and nothing anywhere in the
+// response to say the filter had not been applied. That is the same silence the
+// 400 on an unknown category exists to break, arrived at from the other side.
+//
+// This deliberately does not become a rule about unknown parameters in general.
+// A stray ?foo= carries no expectation that anything will happen; `category` is
+// a real parameter of this API with a documented meaning, so sending it *is* the
+// expectation. Rejecting it here is also the compatible direction: a later
+// release that implements the filter turns these 400s into 200s, while a client
+// written against today's silent pass-through would have to be corrected.
+func categoryParamRejected(c *fiber.Ctx) bool {
+	got := c.Query("category")
+	if got == "" {
+		return false
+	}
+	zlog.Warn().Str("param", "category").Str("got", got).Str("path", c.Path()).
+		Msg("rejected a query parameter this endpoint does not honour")
+	// The route pattern rather than c.Path(), so /api/events/tags/:tag names
+	// itself instead of echoing whichever tag the caller happened to ask for.
+	c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+		"error": fmt.Sprintf(
+			"category is not a filter on %s, so it is refused rather than ignored. "+
+				"Only /api/events supports ?category=", c.Route().Path),
+	})
+	return true
+}
+
 // eventOrder is the sort every paginated list endpoint uses: newest first, with
 // id breaking ties.
 //
@@ -437,6 +472,12 @@ func getEventsByTagHandler(c *fiber.Ctx) error {
 		})
 	}
 
+	// The tag filter does not compose with the category filter. See
+	// categoryParamRejected.
+	if categoryParamRejected(c) {
+		return nil
+	}
+
 	page, limit, ok := pagination(c)
 	if !ok {
 		return nil
@@ -600,6 +641,11 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 
 	if query == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Search query is required"})
+	}
+
+	// Search does not narrow by category. See categoryParamRejected.
+	if categoryParamRejected(c) {
+		return nil
 	}
 
 	page, limit, ok := pagination(c)

--- a/main.go
+++ b/main.go
@@ -287,6 +287,52 @@ type TagInfo struct {
 	Count int    `json:"count"`
 }
 
+// Structure for the /api/categories response
+type CategoryInfo struct {
+	Category string `json:"category"`
+	Count    int    `json:"count"`
+}
+
+// Handler for /api/categories — the counterpart to /api/tags, and what a client
+// needs to build a filter UI without fetching every event to discover what
+// exists.
+//
+// Simpler than getTagsHandler in one way that matters: tags are a JSON array,
+// so that query joins through json_each and must COUNT(DISTINCT e.id) to avoid
+// counting a row twice when it lists a tag twice. category is exactly one value
+// per row, so a plain COUNT(*) is already an event count and cannot disagree
+// with /api/events?category=.
+func getCategoriesHandler(c *fiber.Ctx) error {
+	lang := c.Query("lang", "en")
+	db := dbFor(c)
+
+	zlog.Info().Str("lang", lang).Msg("getCategoriesHandler called")
+
+	var result []CategoryInfo
+	// NOTHING MAY FOLLOW THE FINAL SEMICOLON — see getTagsHandler for what a
+	// trailing comment does to this driver. It is not a style rule.
+	sqlQuery := `
+SELECT
+    LOWER(TRIM(category)) AS category,
+    COUNT(*) AS count
+FROM
+    events
+WHERE
+    category IS NOT NULL
+    AND TRIM(category) != ''
+GROUP BY
+    LOWER(TRIM(category))
+ORDER BY
+    category ASC;`
+	if err := db.Raw(sqlQuery).Scan(&result).Error; err != nil {
+		zlog.Error().Str("lang", lang).Err(err).Msg("getCategoriesHandler: Error executing raw SQL for categories")
+		return queryFailed(c, err, "Failed to retrieve categories from database")
+	}
+
+	zlog.Info().Int("category_count", len(result)).Str("lang", lang).Msg("getCategoriesHandler: Successfully retrieved categories")
+	return c.JSON(fiber.Map{"data": result})
+}
+
 // Handler for /api/tags
 func getTagsHandler(c *fiber.Ctx) error {
 	lang := c.Query("lang", "en") // Default to 'en' if not specified
@@ -462,6 +508,26 @@ func getAllEventsHandler(c *fiber.Ctx) error {
 			return badParam(c, "day", dayStr, "1–31")
 		}
 		query = query.Where("strftime('%d', date) = ?", pad2(dayStr))
+	}
+
+	// category is validated against the vocabulary this artifact actually
+	// carries, read at boot by loadCategories. An unknown value is a 400 for
+	// the same reason a malformed month is: answering 200 with an empty list
+	// makes "there is no such category" indistinguishable from "that category
+	// has no events", and a client cannot tell a typo from a quiet corner of
+	// the corpus.
+	//
+	// Matched case-insensitively, like the tag filter, and lowercased on the
+	// way in because every stored value is lowercase.
+	if categoryStr := c.Query("category"); categoryStr != "" {
+		want := strings.ToLower(strings.TrimSpace(categoryStr))
+		if !categoriesByLang[lang].known(want) {
+			return badParam(c, "category", categoryStr, "one of: "+categoriesByLang[lang].list())
+		}
+		// LOWER on the column, not a bare equality: the closed set is enforced
+		// by the publisher rather than by the schema, so this must not depend
+		// on the stored casing being what it is today.
+		query = query.Where("LOWER(TRIM(category)) = ?", want)
 	}
 
 	// First, get the total count of records that match the filter
@@ -654,6 +720,19 @@ func main() {
 	}
 	zlog.Info().Str("db_path", dbPathRU).Msg("Russian database initialized")
 
+	// --- Category vocabulary ---
+	// Read from the artifacts rather than compiled in, so a category canonical
+	// adds works as soon as its data is published rather than after a rebuild
+	// and a deploy. See loadCategories.
+	for lang, db := range map[string]*gorm.DB{"en": DB_EN, "ru": DB_RU} {
+		set, err := loadCategories(db)
+		if err != nil {
+			zlog.Fatal().Str("lang", lang).Err(err).Msg("Failed to read the category vocabulary")
+		}
+		categoriesByLang[lang] = set
+		zlog.Info().Str("lang", lang).Int("categories", len(set.sorted)).Msg("Category vocabulary loaded")
+	}
+
 	// --- Health snapshot ---
 	healthSnapshot, err = buildHealthSnapshot(map[string]struct {
 		Path string
@@ -748,6 +827,7 @@ func main() {
 	// deadline. dbFor picks the deadline up from the request context.
 	api.Get("/events/:id", timeout.NewWithContext(getEventHandler, queryTimeout))
 	api.Get("/tags", timeout.NewWithContext(getTagsHandler, queryTimeout))
+	api.Get("/categories", timeout.NewWithContext(getCategoriesHandler, queryTimeout))
 	api.Get("/events/tags/:tag", timeout.NewWithContext(getEventsByTagHandler, queryTimeout))
 	api.Get("/events", timeout.NewWithContext(getAllEventsHandler, queryTimeout))
 

--- a/main.go
+++ b/main.go
@@ -792,6 +792,16 @@ func main() {
 					"?category= will be rejected and /api/categories will be empty")
 			continue
 		}
+		// The column is there and empty. Upstream broke validator invariant 13:
+		// no row carries a category, so ?category= can only be rejected. Warn,
+		// because an info line reading `categories: 0` is not something anyone
+		// reads a boot log to find.
+		if len(set.sorted) == 0 {
+			zlog.Warn().Str("lang", lang).
+				Msg("This artifact has a category column but no categories: no row carries a " +
+					"value. ?category= will be rejected and /api/categories will be empty")
+			continue
+		}
 		zlog.Info().Str("lang", lang).Int("categories", len(set.sorted)).Msg("Category vocabulary loaded")
 	}
 

--- a/tests/boot_test.go
+++ b/tests/boot_test.go
@@ -29,6 +29,10 @@ type healthDoc struct {
 			Indexed    int64 `json:"indexed"`
 			Consistent bool  `json:"consistent"`
 		} `json:"fts"`
+		Categories struct {
+			Present bool `json:"present"`
+			Count   int  `json:"count"`
+		} `json:"categories"`
 	} `json:"databases"`
 }
 

--- a/tests/boot_test.go
+++ b/tests/boot_test.go
@@ -346,6 +346,52 @@ func TestIndexedIsNotReadFromTheVirtualTable(t *testing.T) {
 	}
 }
 
+// TestTagsAnswersWithAnArrayWhenThereAreNone pins the shape of the one response
+// in this service that could still be JSON null.
+//
+// /api/tags scans into its slice with Raw().Scan(), which leaves it nil when
+// nothing matches, and a nil slice marshals to null rather than []. Search hit
+// this and was fixed; /api/categories was written correctly for the same reason;
+// this endpoint kept the old shape, so two sibling list endpoints answered
+// differently on the same artifact and a client had to special-case one of them.
+//
+// It takes an artifact where no row carries a usable tag to reach, which is why
+// no existing test could: every fixture and every release has tags.
+func TestTagsAnswersWithAnArrayWhenThereAreNone(t *testing.T) {
+	dir := stageArtifact(t, func(db *sql.DB) error {
+		_, err := db.Exec(`UPDATE events SET tags = '[]'`)
+		return err
+	})
+
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("the service refused to start against an artifact with no tags: %v\n"+
+			"--- log ---\n%s", startErr, serviceLog)
+	}
+
+	var raw struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if code := getFrom(t, base, "/api/tags?lang=ru", &raw); code != http.StatusOK {
+		t.Fatalf("/api/tags: want 200, got %d", code)
+	}
+	if string(raw.Data) != "[]" {
+		t.Errorf("/api/tags: want an empty array, got %s — null is what a nil slice marshals "+
+			"to, and a caller iterating the list has to special-case it", raw.Data)
+	}
+
+	// The control: nothing about this artifact stops the rest of the service
+	// answering, so an empty list here is the real answer rather than a failure
+	// that happens to render as one.
+	var list eventList
+	if code := getFrom(t, base, "/api/events?lang=ru&limit=100", &list); code != http.StatusOK {
+		t.Fatalf("/api/events: want 200, got %d", code)
+	}
+	if list.Pagination.Total != 5 {
+		t.Errorf("/api/events total: want 5, got %d", list.Pagination.Total)
+	}
+}
+
 func fetchJSON(t *testing.T, url string, into interface{}) {
 	t.Helper()
 	res, err := http.Get(url)

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -117,6 +117,65 @@ func TestUnknownCategoryIsRejected(t *testing.T) {
 	}
 }
 
+// TestCategoryIsRejectedWhereItIsNotAFilter covers the two endpoints that return
+// events and do not filter by category.
+//
+// Both accepted the parameter and ignored it: &category=bitcoin on a search
+// answered 200 with every match, and nothing in that response distinguishes it
+// from a filter that ran. That is the silent empty result's mirror image — a
+// silent *unfiltered* result — and the same argument applies, so the parameter
+// is refused where it does nothing.
+//
+// The controls matter here: without them a handler that rejected every request
+// would pass.
+func TestCategoryIsRejectedWhereItIsNotAFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		ok       string // must answer 200 and return events
+		rejected string // the same request with a category appended
+	}{
+		{
+			name:     "search",
+			ok:       "/api/search?lang=ru&q=satoshi",
+			rejected: "/api/search?lang=ru&q=satoshi&category=bitcoin",
+		},
+		{
+			name:     "events by tag",
+			ok:       "/api/events/tags/satoshi?lang=ru",
+			rejected: "/api/events/tags/satoshi?lang=ru&category=bitcoin",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var list eventList
+			if code := getAs(t, apiKey3, tc.ok, &list); code != http.StatusOK {
+				t.Fatalf("%s: want 200, got %d", tc.ok, code)
+			}
+			if len(list.Events) == 0 {
+				t.Fatalf("%s returned no events, so the rejection below proves nothing", tc.ok)
+			}
+
+			var body struct {
+				Error string `json:"error"`
+			}
+			code := getAs(t, apiKey3, tc.rejected, &body)
+			if code != http.StatusBadRequest {
+				t.Fatalf("%s: want 400, got %d — the parameter is not honoured here, and "+
+					"answering 200 leaves the caller unable to tell that their filter was "+
+					"dropped", tc.rejected, code)
+			}
+			// `bitcoin` is a real category in the ru artifact, so this is not a
+			// vocabulary rejection wearing the wrong coat: the endpoint has to
+			// refuse the parameter itself.
+			if !strings.Contains(body.Error, "category") {
+				t.Errorf("the rejection does not name the parameter: %q", body.Error)
+			}
+			if !strings.Contains(body.Error, "/api/events") {
+				t.Errorf("the rejection does not say where the filter does work: %q", body.Error)
+			}
+		})
+	}
+}
+
 // TestUnknownLangStillValidatesCategory is a regression test for a bug that
 // survived the first round of these tests because every one of them named a
 // real language.

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -89,6 +89,38 @@ func TestUnknownCategoryIsRejected(t *testing.T) {
 	}
 }
 
+// TestUnknownLangStillValidatesCategory is a regression test for a bug that
+// survived the first round of these tests because every one of them named a
+// real language.
+//
+// An unrecognised lang silently serves English — documented, and deliberate.
+// But the filter validated against categoriesByLang[<raw lang>], so `lang=xx`
+// found no vocabulary, treated "no vocabulary" as "nothing to check", and
+// answered 200 with an empty list for a category that does not exist. One
+// spelling of one parameter reopened the silent-empty-result hole the 400 was
+// added to close, which is a good argument for testing the fallback path of
+// anything keyed by a caller-supplied value.
+func TestUnknownLangStillValidatesCategory(t *testing.T) {
+	for _, lang := range []string{"xx", "EN", "de", ""} {
+		t.Run("lang="+lang, func(t *testing.T) {
+			var body struct {
+				Error string `json:"error"`
+			}
+			code := getAs(t, apiKey2, "/api/events?lang="+lang+"&category=nonesuch", &body)
+			if code != http.StatusBadRequest {
+				t.Errorf("lang=%q category=nonesuch: want 400, got %d — an unknown category "+
+					"must be rejected whatever language the caller named", lang, code)
+			}
+		})
+	}
+
+	// The other half: the fallback must still accept what English carries.
+	var list eventList
+	if code := getAs(t, apiKey2, "/api/events?lang=xx&category=mustread", &list); code != http.StatusOK {
+		t.Errorf("lang=xx category=mustread: want 200, got %d", code)
+	}
+}
+
 // TestCategoryFilterIsCaseInsensitive matches the documented behaviour of the
 // tag filter, so the two do not disagree about how a caller may spell things.
 func TestCategoryFilterIsCaseInsensitive(t *testing.T) {

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -98,6 +98,19 @@ func TestCategoryFilterIsNotTagFilter(t *testing.T) {
 // indistinguishable from a category that genuinely has no events, and a client
 // cannot tell its own typo from a quiet corner of the corpus.
 func TestUnknownCategoryIsRejected(t *testing.T) {
+	// What the artifact carries, asked of the service rather than listed here,
+	// so this cannot drift from the fixture. Every one of these must appear in
+	// the rejection message.
+	var vocab struct {
+		Data []categoryInfo `json:"data"`
+	}
+	if code := getAs(t, apiKey2, "/api/categories?lang=ru", &vocab); code != http.StatusOK {
+		t.Fatalf("/api/categories: want 200, got %d", code)
+	}
+	if len(vocab.Data) == 0 {
+		t.Fatal("the fixture reports no categories, so the assertions below would pass vacuously")
+	}
+
 	for _, bad := range []string{"nonesuch", "bitcion", "Bitcoin Core", "'; DROP TABLE events;--", "%"} {
 		t.Run(bad, func(t *testing.T) {
 			var body struct {
@@ -109,9 +122,21 @@ func TestUnknownCategoryIsRejected(t *testing.T) {
 			}
 			// The message must name what would have been accepted. A 400 that
 			// only says "invalid" leaves the caller guessing at a vocabulary
-			// they cannot see.
-			if body.Error == "" {
-				t.Error("a rejected category must explain itself")
+			// they cannot see — and asserting merely that the message is
+			// non-empty would accept exactly that, which is why this checks the
+			// vocabulary is in it rather than checking that something was said.
+			for _, ci := range vocab.Data {
+				if !strings.Contains(body.Error, ci.Category) {
+					t.Errorf("category=%q was rejected with %q, which does not name %q. A caller "+
+						"who cannot see the vocabulary has to guess at it from this message.",
+						bad, body.Error, ci.Category)
+				}
+			}
+			// And it must echo what was rejected, or a caller batching requests
+			// cannot tell which one the message is about.
+			if !strings.Contains(body.Error, bad) {
+				t.Errorf("category=%q was rejected with %q, which does not repeat the value sent",
+					bad, body.Error)
 			}
 		})
 	}

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -1,9 +1,14 @@
 package tests
 
 import (
+	"database/sql"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
 
 type categoryInfo struct {
@@ -11,14 +16,37 @@ type categoryInfo struct {
 	Count    int    `json:"count"`
 }
 
+// getFrom is getAs against a service other than the suite's own, for the tests
+// that boot an instance on a deliberately odd artifact.
+func getFrom(t *testing.T, base, path string, into interface{}) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, base+path, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	req.Header.Set("X-API-KEY", apiKey)
+
+	res, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer res.Body.Close()
+	if into != nil && strings.Contains(res.Header.Get("Content-Type"), "application/json") {
+		_ = json.NewDecoder(res.Body).Decode(into)
+	} else {
+		_, _ = io.Copy(io.Discard, res.Body)
+	}
+	return res.StatusCode
+}
+
 // TestCategoryFilter covers the filter's happy path against the fixture, whose
 // categories are deliberately not equal to any row's first tag — a filter that
 // accidentally matched on tags would pass a fixture where the two agreed.
 func TestCategoryFilter(t *testing.T) {
-	// Fixture categories, RU: holiday(1), mustread(1), archives(1), first(1),
-	// bitcoin(1). `bitcoin` is the important one: it is a category carried by a
-	// row whose tags do not include it, which is the exact shape canonical has
-	// after the tag was retired.
+	// Fixture categories, RU: holiday(1), mustread(1), archives(1), bitcoin(1),
+	// and syntheticCategory(1). `bitcoin` is the important one: it is a category
+	// carried by a row whose tags do not include it, which is the exact shape
+	// canonical has after the tag was retired.
 	for _, tc := range []struct {
 		category string
 		want     int
@@ -26,7 +54,7 @@ func TestCategoryFilter(t *testing.T) {
 		{"holiday", 1},
 		{"archives", 1},
 		{"bitcoin", 1},
-		{"first", 1},
+		{syntheticCategory, 1},
 	} {
 		t.Run(tc.category, func(t *testing.T) {
 			var list eventList
@@ -193,11 +221,99 @@ func TestCategoriesEndpoint(t *testing.T) {
 	}
 }
 
+// TestVocabularyComesFromTheArtifactNotTheBinary is the one assertion that can
+// distinguish this service's design — read the vocabulary out of the artifact at
+// boot — from the compiled-in list it was written to avoid.
+//
+// Nothing else here can. Every other fixture category is a real canonical value,
+// so a hardcoded list contains them all and every other test in this file passes
+// against it; that was measured, not assumed. `syntheticCategory` is a value no
+// such list could hold, so the filter accepts it only if loadCategories really
+// did read the artifact.
+//
+// This is the 2026-08-10 scenario in miniature: canonical added `security` a day
+// after the column shipped, and a binary carrying its own list would have
+// answered 400 to a category the data already contained until someone built and
+// deployed a new one.
+func TestVocabularyComesFromTheArtifactNotTheBinary(t *testing.T) {
+	var list eventList
+	code := getAs(t, apiKey2, "/api/events?lang=ru&category="+url.QueryEscape(syntheticCategory), &list)
+	if code != http.StatusOK {
+		t.Fatalf("category=%q answered %d. The fixture carries this value, so the only way "+
+			"to reject it is to validate against a vocabulary that did not come from the "+
+			"artifact — which is the design this test exists to pin.", syntheticCategory, code)
+	}
+	// Without this the test would pass against a filter that accepts everything
+	// and matches nothing, which is the failure mode ?category= exists to avoid.
+	if list.Pagination.Total != 1 {
+		t.Errorf("category=%q: want 1 event, got %d — the fixture row carrying it is gone, "+
+			"and with it the only proof that the vocabulary is read from the data",
+			syntheticCategory, list.Pagination.Total)
+	}
+
+	// The endpoint must report it too, or a client could never discover it.
+	var body struct {
+		Data []categoryInfo `json:"data"`
+	}
+	if code := getAs(t, apiKey2, "/api/categories?lang=ru", &body); code != http.StatusOK {
+		t.Fatalf("/api/categories: want 200, got %d", code)
+	}
+	for _, ci := range body.Data {
+		if ci.Category == syntheticCategory {
+			return
+		}
+	}
+	t.Errorf("/api/categories does not report %q, though the artifact carries it; the "+
+		"endpoint is not reading the same data the filter validates against", syntheticCategory)
+}
+
+// TestCategoryVocabularyIsPerArtifact pins that each language validates against
+// its own file rather than a set shared between them.
+//
+// `bitcoin` is carried by RU fixture event 4 and by no EN row, so it must be a
+// valid filter in one language and a 400 in the other. In production the two
+// artifacts happen to carry identical category *names*, which is exactly why
+// this cannot be left to canonical to demonstrate — the day they diverge is the
+// day a shared vocabulary starts answering 200 with an empty list.
+//
+// It is also the assertion that fails if the two languages' vocabularies are
+// ever loaded into the wrong slots, which the RU-superset fixture would
+// otherwise hide in one direction.
+func TestCategoryVocabularyIsPerArtifact(t *testing.T) {
+	var ru eventList
+	if code := getAs(t, apiKey2, "/api/events?lang=ru&category=bitcoin", &ru); code != http.StatusOK {
+		t.Fatalf("lang=ru category=bitcoin: want 200, got %d", code)
+	}
+	if ru.Pagination.Total == 0 {
+		t.Fatal("no ru event carries the bitcoin category; the fixture no longer models the " +
+			"asymmetry this test needs")
+	}
+
+	// The same value against the artifact that does not carry it.
+	for _, lang := range []string{"en", "xx"} {
+		t.Run("lang="+lang, func(t *testing.T) {
+			var body struct {
+				Error string `json:"error"`
+			}
+			code := getAs(t, apiKey2, "/api/events?lang="+lang+"&category=bitcoin", &body)
+			if code != http.StatusBadRequest {
+				t.Errorf("lang=%s category=bitcoin: want 400, got %d — no english row carries "+
+					"that category, so a 200 here means the filter validated against the "+
+					"wrong artifact's vocabulary (xx falls back to english)", lang, code)
+			}
+		})
+	}
+}
+
 // TestEveryCategoryInTheDataIsAccepted closes the loop the boot-derived
 // vocabulary exists for: whatever the artifact carries must be a valid filter
-// value. A hardcoded list would drift from the data and fail exactly here —
-// which is what would have happened on 2026-08-10, when canonical added
-// `security` a day after the column shipped.
+// value.
+//
+// On its own this asserts only that two reads of the same artifact agree, which
+// a hardcoded list satisfies just as well — TestVocabularyComesFromTheArtifact-
+// NotTheBinary is what actually pins the design. This one still earns its place
+// by covering every value rather than one, so a filter that accepted only part
+// of the vocabulary would fail here.
 func TestEveryCategoryInTheDataIsAccepted(t *testing.T) {
 	var body struct {
 		Data []categoryInfo `json:"data"`
@@ -240,5 +356,89 @@ func TestCategoriesAreLanguageSpecific(t *testing.T) {
 		if c.Category == "bitcoin" {
 			t.Error("en reports a bitcoin category; that row exists only in the ru fixture")
 		}
+	}
+}
+
+// TestServiceBootsWithoutACategoryColumn is a regression test for a boot failure
+// that only an old artifact could trigger, which is precisely why nothing caught
+// it: every fixture and every current release carries the column.
+//
+// `category` arrived on 2026-08-09. Every release before that has no such
+// column, and those files are still on the box as rollback targets —
+// publish-db.sh's rollback() re-points `current` at the previous release and
+// restarts the service. Reading the vocabulary at boot made a missing column a
+// fatal error, so this binary refused to start against any of them: a rollback
+// became an outage, and a binary deploy silently required an artifact of at
+// least a given age. Confirmed against a real superseded artifact — the pre-PR
+// binary served it, this one exited with `no such column: category`.
+//
+// So the service must boot, keep answering everything that does not depend on
+// the column, and refuse only the filter it genuinely cannot answer.
+func TestServiceBootsWithoutACategoryColumn(t *testing.T) {
+	dir := stageArtifact(t, func(db *sql.DB) error {
+		_, err := db.Exec(`ALTER TABLE events DROP COLUMN category`)
+		return err
+	})
+
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("the service refused to start against an artifact predating the category "+
+			"column. That artifact is a rollback target, and everything except ?category= "+
+			"works perfectly well on it: %v\n--- log ---\n%s", startErr, serviceLog)
+	}
+	if !strings.Contains(serviceLog, "no category column") {
+		t.Errorf("the service degraded silently; nothing in its log says the artifact has no "+
+			"category column:\n%s", serviceLog)
+	}
+
+	// Everything not keyed on the column still works.
+	var list eventList
+	if code := getFrom(t, base, "/api/events?lang=ru&limit=100", &list); code != http.StatusOK {
+		t.Fatalf("/api/events: want 200, got %d", code)
+	}
+	if list.Pagination.Total != 5 {
+		t.Errorf("/api/events total: want 5, got %d", list.Pagination.Total)
+	}
+
+	// Search especially. It is the one handler that enumerates its columns by
+	// hand instead of letting GORM derive them, so it is the one that names
+	// e.category into a table that has none — and it answered 500 to every query
+	// while the rest of the service was fine. Booting and then failing every
+	// search is not a rollback that worked.
+	var found eventList
+	if code := getFrom(t, base, "/api/search?lang=ru&q=satoshi&limit=100", &found); code != http.StatusOK {
+		t.Errorf("/api/search: want 200, got %d — the hand-written SELECT in "+
+			"ftsSearchHandler still names a column this artifact does not have", code)
+	}
+	if len(found.Events) == 0 {
+		t.Error("/api/search returned nothing for a term the fixture carries; a 200 with an " +
+			"empty list is the failure this would otherwise hide")
+	}
+
+	// The filter cannot be answered, so it must be refused — not answered 200
+	// with an empty list, which is the whole reason ?category= validates at all.
+	var errBody struct {
+		Error string `json:"error"`
+	}
+	if code := getFrom(t, base, "/api/events?lang=ru&category=bitcoin", &errBody); code != http.StatusBadRequest {
+		t.Errorf("?category= against an artifact with no category column: want 400, got %d. "+
+			"200 would be an empty list indistinguishable from a real one, and 500 would "+
+			"be a server error for a question the server can answer", code)
+	}
+	if !strings.Contains(errBody.Error, "category") {
+		t.Errorf("the rejection does not explain itself: %q", errBody.Error)
+	}
+
+	// And the discovery endpoint reports an empty list rather than failing, or
+	// returning the JSON null a nil slice marshals to.
+	var raw struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if code := getFrom(t, base, "/api/categories?lang=ru", &raw); code != http.StatusOK {
+		t.Fatalf("/api/categories: want 200, got %d", code)
+	}
+	if string(raw.Data) != "[]" {
+		t.Errorf("/api/categories: want an empty array, got %s — null is what a nil slice "+
+			"marshals to, and a caller has to special-case it", raw.Data)
 	}
 }

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -443,6 +443,48 @@ func TestCategoriesAreLanguageSpecific(t *testing.T) {
 	}
 }
 
+// TestHealthReportsTheVocabularyItServes is the assertion publish-db.sh depends
+// on. Its verify step parses /health and would otherwise have no way to see that
+// an artifact carries no categories: the boot log says so once, and nothing reads
+// a boot log during a release.
+//
+// The count is checked against /api/categories rather than against a number
+// written here. A literal would pass just as well against a field populated from
+// a second query, or from a constant — what has to be true is that /health
+// describes the vocabulary the service is actually validating against, and the
+// endpoint is where that vocabulary is observable.
+func TestHealthReportsTheVocabularyItServes(t *testing.T) {
+	var health healthDoc
+	fetchJSON(t, baseURL+"/health", &health)
+
+	for _, lang := range []string{"en", "ru"} {
+		t.Run(lang, func(t *testing.T) {
+			db, found := health.Databases[lang]
+			if !found {
+				t.Fatalf("%s: absent from /health", lang)
+			}
+			if !db.Categories.Present {
+				t.Fatalf("%s: /health reports no category column, but the fixture has one", lang)
+			}
+
+			var body struct {
+				Data []categoryInfo `json:"data"`
+			}
+			if code := getAs(t, apiKey3, "/api/categories?lang="+lang, &body); code != http.StatusOK {
+				t.Fatalf("/api/categories: want 200, got %d", code)
+			}
+			if len(body.Data) == 0 {
+				t.Fatal("/api/categories returned nothing, so the count below proves nothing")
+			}
+			if db.Categories.Count != len(body.Data) {
+				t.Errorf("%s: /health says %d categories, /api/categories lists %d — the "+
+					"release check would be asserting against a number the service does not "+
+					"filter by", lang, db.Categories.Count, len(body.Data))
+			}
+		})
+	}
+}
+
 // TestEmptyVocabularyRejectsEveryCategory covers the artifact that has the
 // column and carries no values in it.
 //
@@ -515,6 +557,27 @@ func TestEmptyVocabularyRejectsEveryCategory(t *testing.T) {
 	}
 	if string(raw.Data) != "[]" {
 		t.Errorf("/api/categories: want an empty array, got %s", raw.Data)
+	}
+
+	// This is the state publish-db.sh must refuse to publish, so /health has to
+	// distinguish it from an artifact predating the column: the column is there,
+	// and nothing is in it.
+	var health healthDoc
+	fetchJSON(t, base+"/health", &health)
+	if health.Status != "ok" {
+		t.Errorf("status: want ok — an empty vocabulary is not an index problem, and marking "+
+			"it degraded would alarm for as long as such an artifact was served, got %q",
+			health.Status)
+	}
+	for lang, db := range health.Databases {
+		if !db.Categories.Present {
+			t.Errorf("%s: /health says the column is absent; it is present and empty, which is "+
+				"a different failure with a different fix", lang)
+		}
+		if db.Categories.Count != 0 {
+			t.Errorf("%s: /health reports %d categories on an artifact where every value is NULL",
+				lang, db.Categories.Count)
+		}
 	}
 }
 
@@ -599,5 +662,24 @@ func TestServiceBootsWithoutACategoryColumn(t *testing.T) {
 	if string(raw.Data) != "[]" {
 		t.Errorf("/api/categories: want an empty array, got %s — null is what a nil slice "+
 			"marshals to, and a caller has to special-case it", raw.Data)
+	}
+
+	// /health must say the column is absent rather than that the vocabulary is
+	// empty. Serving this artifact is a correct outcome — it is what a rollback
+	// looks like — and the release check treats the two differently.
+	var health healthDoc
+	fetchJSON(t, base+"/health", &health)
+	if health.Status != "ok" {
+		t.Errorf("status: want ok, got %q — a rollback target is not a degraded service",
+			health.Status)
+	}
+	for lang, db := range health.Databases {
+		if db.Categories.Present {
+			t.Errorf("%s: /health claims a category column on an artifact that has none", lang)
+		}
+		if db.Categories.Count != 0 {
+			t.Errorf("%s: /health reports %d categories with no column to hold them",
+				lang, db.Categories.Count)
+		}
 	}
 }

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -1,0 +1,212 @@
+package tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type categoryInfo struct {
+	Category string `json:"category"`
+	Count    int    `json:"count"`
+}
+
+// TestCategoryFilter covers the filter's happy path against the fixture, whose
+// categories are deliberately not equal to any row's first tag — a filter that
+// accidentally matched on tags would pass a fixture where the two agreed.
+func TestCategoryFilter(t *testing.T) {
+	// Fixture categories, RU: holiday(1), mustread(1), archives(1), first(1),
+	// bitcoin(1). `bitcoin` is the important one: it is a category carried by a
+	// row whose tags do not include it, which is the exact shape canonical has
+	// after the tag was retired.
+	for _, tc := range []struct {
+		category string
+		want     int
+	}{
+		{"holiday", 1},
+		{"archives", 1},
+		{"bitcoin", 1},
+		{"first", 1},
+	} {
+		t.Run(tc.category, func(t *testing.T) {
+			var list eventList
+			if code := getAs(t, apiKey2, "/api/events?lang=ru&category="+tc.category, &list); code != http.StatusOK {
+				t.Fatalf("want 200, got %d", code)
+			}
+			if list.Pagination.Total != tc.want {
+				t.Errorf("category=%s: want %d events, got %d", tc.category, tc.want, list.Pagination.Total)
+			}
+			for _, e := range list.Events {
+				if e.Category != tc.category {
+					t.Errorf("event %d came back under category=%s but carries %q", e.ID, tc.category, e.Category)
+				}
+			}
+		})
+	}
+}
+
+// TestCategoryFilterIsNotTagFilter is the assertion that the two are wired to
+// different columns. Fixture event 4 (RU) is category `bitcoin` and tagged
+// `satoshi`; no row is tagged `bitcoin` at all, exactly as in canonical.
+func TestCategoryFilterIsNotTagFilter(t *testing.T) {
+	var byCategory, byTag eventList
+	if code := getAs(t, apiKey2, "/api/events?lang=ru&category=bitcoin", &byCategory); code != http.StatusOK {
+		t.Fatalf("category=bitcoin: want 200, got %d", code)
+	}
+	if code := getAs(t, apiKey2, "/api/events/tags/bitcoin?lang=ru", &byTag); code != http.StatusOK {
+		t.Fatalf("tags/bitcoin: want 200, got %d", code)
+	}
+	if byCategory.Pagination.Total == 0 {
+		t.Fatal("category=bitcoin matched nothing; the fixture no longer models the case this guards")
+	}
+	if byTag.Pagination.Total != 0 {
+		t.Errorf("tags/bitcoin matched %d events: `bitcoin` is a category, not a tag",
+			byTag.Pagination.Total)
+	}
+}
+
+// TestUnknownCategoryIsRejected is the same argument as the date filters: an
+// unknown value must not answer 200 with an empty list, because that is
+// indistinguishable from a category that genuinely has no events, and a client
+// cannot tell its own typo from a quiet corner of the corpus.
+func TestUnknownCategoryIsRejected(t *testing.T) {
+	for _, bad := range []string{"nonesuch", "bitcion", "Bitcoin Core", "'; DROP TABLE events;--", "%"} {
+		t.Run(bad, func(t *testing.T) {
+			var body struct {
+				Error string `json:"error"`
+			}
+			code := getAs(t, apiKey2, "/api/events?lang=ru&category="+url.QueryEscape(bad), &body)
+			if code != http.StatusBadRequest {
+				t.Fatalf("category=%q: want 400, got %d", bad, code)
+			}
+			// The message must name what would have been accepted. A 400 that
+			// only says "invalid" leaves the caller guessing at a vocabulary
+			// they cannot see.
+			if body.Error == "" {
+				t.Error("a rejected category must explain itself")
+			}
+		})
+	}
+}
+
+// TestCategoryFilterIsCaseInsensitive matches the documented behaviour of the
+// tag filter, so the two do not disagree about how a caller may spell things.
+func TestCategoryFilterIsCaseInsensitive(t *testing.T) {
+	var lower, upper eventList
+	getAs(t, apiKey2, "/api/events?lang=ru&category=bitcoin", &lower)
+	getAs(t, apiKey2, "/api/events?lang=ru&category=BITCOIN", &upper)
+
+	if lower.Pagination.Total == 0 {
+		t.Fatal("category=bitcoin matched nothing")
+	}
+	if lower.Pagination.Total != upper.Pagination.Total {
+		t.Errorf("case sensitivity: bitcoin=%d BITCOIN=%d",
+			lower.Pagination.Total, upper.Pagination.Total)
+	}
+}
+
+// TestCategoryFilterComposesWithDateFilters proves the filters AND together
+// rather than one silently replacing the other.
+func TestCategoryFilterComposesWithDateFilters(t *testing.T) {
+	// Fixture RU event 1 is 1881-09-29, category holiday.
+	var hit, miss eventList
+	if code := getAs(t, apiKey2, "/api/events?lang=ru&category=holiday&month=9&day=29", &hit); code != http.StatusOK {
+		t.Fatalf("want 200, got %d", code)
+	}
+	if hit.Pagination.Total != 1 {
+		t.Errorf("category+date: want 1, got %d", hit.Pagination.Total)
+	}
+	// Same category, a date it is not on.
+	if code := getAs(t, apiKey2, "/api/events?lang=ru&category=holiday&month=1&day=1", &miss); code != http.StatusOK {
+		t.Fatalf("want 200, got %d", code)
+	}
+	if miss.Pagination.Total != 0 {
+		t.Errorf("category+wrong date: want 0, got %d", miss.Pagination.Total)
+	}
+}
+
+// TestCategoriesEndpoint pins /api/categories against the fixture, and against
+// the filter: the two must not be able to disagree.
+func TestCategoriesEndpoint(t *testing.T) {
+	var body struct {
+		Data []categoryInfo `json:"data"`
+	}
+	if code := getAs(t, apiKey2, "/api/categories?lang=ru", &body); code != http.StatusOK {
+		t.Fatalf("want 200, got %d", code)
+	}
+	if len(body.Data) == 0 {
+		t.Fatal("/api/categories returned nothing")
+	}
+
+	// Alphabetical, like /api/tags, so a client can render it without sorting.
+	for i := 1; i < len(body.Data); i++ {
+		if body.Data[i-1].Category > body.Data[i].Category {
+			t.Errorf("not sorted: %q before %q", body.Data[i-1].Category, body.Data[i].Category)
+		}
+	}
+
+	// Every count must equal what the filter returns for that category. This
+	// is the /api/tags-versus-/api/events/tags disagreement, pre-empted: one
+	// counts rows, the other counts events, and for category they are the same
+	// thing only because there is exactly one value per row.
+	for _, ci := range body.Data {
+		var list eventList
+		if code := getAs(t, apiKey2, "/api/events?lang=ru&category="+ci.Category, &list); code != http.StatusOK {
+			t.Fatalf("category %q: want 200, got %d", ci.Category, code)
+		}
+		if list.Pagination.Total != ci.Count {
+			t.Errorf("category %q: /api/categories says %d, /api/events?category= says %d",
+				ci.Category, ci.Count, list.Pagination.Total)
+		}
+	}
+}
+
+// TestEveryCategoryInTheDataIsAccepted closes the loop the boot-derived
+// vocabulary exists for: whatever the artifact carries must be a valid filter
+// value. A hardcoded list would drift from the data and fail exactly here —
+// which is what would have happened on 2026-08-10, when canonical added
+// `security` a day after the column shipped.
+func TestEveryCategoryInTheDataIsAccepted(t *testing.T) {
+	var body struct {
+		Data []categoryInfo `json:"data"`
+	}
+	if code := getAs(t, apiKey2, "/api/categories?lang=ru", &body); code != http.StatusOK {
+		t.Fatalf("want 200, got %d", code)
+	}
+	for _, ci := range body.Data {
+		var list eventList
+		code := getAs(t, apiKey2, "/api/events?lang=ru&category="+ci.Category, &list)
+		if code != http.StatusOK {
+			t.Errorf("category %q exists in the data but the filter answered %d; the accepted "+
+				"vocabulary and the stored values have diverged", ci.Category, code)
+		}
+	}
+}
+
+// TestCategoriesAreLanguageSpecific guards the same conflation the event
+// endpoints are guarded against: the two artifacts are independent files.
+func TestCategoriesAreLanguageSpecific(t *testing.T) {
+	var ru, en struct {
+		Data []categoryInfo `json:"data"`
+	}
+	getAs(t, apiKey2, "/api/categories?lang=ru", &ru)
+	getAs(t, apiKey2, "/api/categories?lang=en", &en)
+
+	if len(ru.Data) == 0 || len(en.Data) == 0 {
+		t.Fatal("a language returned no categories")
+	}
+	// The RU fixture carries one extra event (id 4, category bitcoin) that the
+	// EN fixture does not, so the two must differ.
+	ruHas := map[string]bool{}
+	for _, c := range ru.Data {
+		ruHas[c.Category] = true
+	}
+	if !ruHas["bitcoin"] {
+		t.Error("ru is missing the bitcoin category, which only its fixture carries")
+	}
+	for _, c := range en.Data {
+		if c.Category == "bitcoin" {
+			t.Error("en reports a bitcoin category; that row exists only in the ru fixture")
+		}
+	}
+}

--- a/tests/category_test.go
+++ b/tests/category_test.go
@@ -359,6 +359,81 @@ func TestCategoriesAreLanguageSpecific(t *testing.T) {
 	}
 }
 
+// TestEmptyVocabularyRejectsEveryCategory covers the artifact that has the
+// column and carries no values in it.
+//
+// The filter used to accept every value in that state, on the reasoning that
+// there was no vocabulary to validate against — so ?category=nonesuch answered
+// 200 with an empty list, which is precisely what the 400 was added to prevent.
+// That permissiveness was written for an artifact predating the column; that
+// case is handled separately now, and this was the only route left to the silent
+// empty result.
+//
+// Reproduced against a copy of a real artifact with `UPDATE events SET category
+// = NULL` before it was written here. Upstream cannot publish such a file
+// without breaking validator invariant 13, which is why nothing else would catch
+// it: this is the API refusing to answer a question it cannot answer, not a
+// guess about what the data will look like.
+func TestEmptyVocabularyRejectsEveryCategory(t *testing.T) {
+	dir := stageArtifact(t, func(db *sql.DB) error {
+		_, err := db.Exec(`UPDATE events SET category = NULL`)
+		return err
+	})
+
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("the service refused to start against an artifact whose category column is "+
+			"empty. Every other endpoint answers correctly on it, exactly as on an artifact "+
+			"predating the column: %v\n--- log ---\n%s", startErr, serviceLog)
+	}
+	// Distinguishes this from the missing-column path, which rejects categories
+	// too — without it this test would pass against an artifact that simply had
+	// no such column, i.e. for the wrong reason.
+	if !strings.Contains(serviceLog, "no categories") {
+		t.Errorf("the service degraded silently; nothing in its log says the column carries "+
+			"no values:\n%s", serviceLog)
+	}
+
+	// The control: the column is there and the rest of the service is fine.
+	var list eventList
+	if code := getFrom(t, base, "/api/events?lang=ru&limit=100", &list); code != http.StatusOK {
+		t.Fatalf("/api/events: want 200, got %d", code)
+	}
+	if list.Pagination.Total != 5 {
+		t.Errorf("/api/events total: want 5, got %d", list.Pagination.Total)
+	}
+
+	// `bitcoin` is a real category in the unmutated fixture, and `nonesuch` never
+	// was: with no vocabulary, both are equally unanswerable and both must be
+	// refused.
+	for _, category := range []string{"nonesuch", "bitcoin"} {
+		var body struct {
+			Error string `json:"error"`
+		}
+		code := getFrom(t, base, "/api/events?lang=ru&category="+category, &body)
+		if code != http.StatusBadRequest {
+			t.Errorf("category=%s against an empty vocabulary: want 400, got %d. 200 is an "+
+				"empty list indistinguishable from a category that genuinely has no events",
+				category, code)
+		}
+		if !strings.Contains(body.Error, "no categories") {
+			t.Errorf("category=%s: the rejection does not say the artifact carries none: %q",
+				category, body.Error)
+		}
+	}
+
+	// And the discovery endpoint agrees, in the shape a client can iterate.
+	var raw struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if code := getFrom(t, base, "/api/categories?lang=ru", &raw); code != http.StatusOK {
+		t.Fatalf("/api/categories: want 200, got %d", code)
+	}
+	if string(raw.Data) != "[]" {
+		t.Errorf("/api/categories: want an empty array, got %s", raw.Data)
+	}
+}
+
 // TestServiceBootsWithoutACategoryColumn is a regression test for a boot failure
 // that only an old artifact could trigger, which is precisely why nothing caught
 // it: every fixture and every current release carries the column.

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -219,13 +219,36 @@ type fixtureRow struct {
 	CreatedAt, UpdatedAt *string
 	Tags, URLPath        string
 	// Mandatory in canonical by validator invariant 13 — one value per row from
-	// a closed set — so every fixture row carries one, and each value below is a
-	// real member of that set rather than an invention. The set is owned by the
+	// a closed set — so every fixture row carries one. The set is owned by the
 	// data and grows (it gained `security` on 2026-08-10), so nothing here
 	// asserts its size; TestFixtureSchemaMatchesCanonical compares columns, not
 	// values, for exactly that reason.
+	//
+	// Every value below is a real member of that set except one, event 5's, and
+	// that exception is the whole point: see syntheticCategory.
 	Category string
 }
+
+// syntheticCategory is deliberately NOT a member of canonical's vocabulary, and
+// it is the only assertion in this suite that can tell the boot-derived
+// vocabulary apart from a hardcoded list.
+//
+// Every other fixture category — holiday, mustread, archives, bitcoin — is a
+// real canonical value, so a compiled-in list would contain all of them and
+// accept all of them. Replacing loadCategories with such a list was measured
+// against this suite before this row existed: `go vet` clean, every test green.
+// The design the filter exists for was pinned by nothing.
+//
+// So one row carries a value no hardcoded list could ever hold. The filter
+// accepts it only if the vocabulary really was read out of the artifact at boot,
+// which is what TestVocabularyComesFromTheArtifactNotTheBinary asserts.
+//
+// This is the same trade the duplicated-tag row (event 3) makes: a fixture
+// deliberately harsher than production, because a test that cannot fail reads
+// like coverage while providing none. It is safe here for the same reason the
+// filter is written the way it is — nothing in the service carries a list of
+// permitted values to disagree with.
+const syntheticCategory = "not-a-canonical-category"
 
 func strptr(s string) *string { return &s }
 
@@ -300,8 +323,10 @@ func fixtureRows(lang string) []fixtureRow {
 			CreatedAt: nil, UpdatedAt: nil,
 			Tags: `["archives"]`, URLPath: "/2008-11-01/a-second-event-on-the-same-day/",
 			// Same tag as event 3 but a different category, so that nothing can
-			// pass by treating the two fields as interchangeable.
-			Category: "first",
+			// pass by treating the two fields as interchangeable — and the one
+			// value in this fixture that canonical does not carry, so that the
+			// vocabulary's origin is provable. See syntheticCategory.
+			Category: syntheticCategory,
 		},
 	}
 	if lang == "ru" {


### PR DESCRIPTION
D3 from the reviewed proposal. `category` has been in every response since #6, but nothing
could filter by it, so a website had to fetch all 581 rows and filter client-side.

**`GET /api/events?category=…`** — a parameter on the existing handler, not a new route. ANDs
with the date filters. Case-insensitive. An unknown value is a `400` naming the accepted set,
for the same reason a malformed `month` is: `200` with an empty list cannot be told apart from
a category that genuinely has no events.

**`GET /api/categories`** — name and count, alphabetical, mirroring `/api/tags`. Simpler than
that query in one way worth noting: tags need `COUNT(DISTINCT e.id)` because `json_each`
multiplies rows, while one category per row makes `COUNT(*)` already an event count, so the
endpoint and the filter cannot disagree. A test asserts they don't.

**The vocabulary is read from the artifact at boot**, not compiled in — one `SELECT DISTINCT`
per language beside the existing FTS probe, no DDL, no writes. This is the part today argued
for: `security` was added to canonical a day after the column shipped, and a hardcoded list
would have rejected it as invalid until a new binary was built *and* deployed, turning a
content edit into a code release. Verified against the live artifacts — `category=security`
answers 200 with no code change.

Both load-bearing tests were watched failing rather than assumed:
- removing the validation makes `TestUnknownCategoryIsRejected` fail (`want 400, got 200`)
- simulating a stale compiled-in list makes `TestEveryCategoryInTheDataIsAccepted` fail with
  "exists in the data but the filter answered 400"

Counts verified against SQL on the real artifacts: ru bitcoin 132, en bitcoin 66, security
16/16, ru lightning 4. Artifacts byte-identical across the new boot query.
