### PR TITLE
feat: serve and filter on the landmark column

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,22 @@ These are the parts that are not guessable from the endpoint list. Each was a re
     the website's page URL. It is present on every row.
 *   **`category` is not `tags[0]`.** Every event has exactly one `category`, and it is what the
     website colours and filters by. Consumers used to derive it from the first tag; tag order
-    carries no meaning now and that inference is wrong. `bitcoin` is the sharp edge: it is a
-    category on 132 RU and 66 EN events and **no longer a tag on any**, so
-    `/api/events/tags/bitcoin` returns an empty list. Filter with `/api/events?category=…` and
-    discover the values with `/api/categories`. The set is closed but **owned by the data and
-    liable to grow** — `security` appeared a day after the column did — so accept unrecognised
-    values rather than hardcoding the list. The service derives the accepted values from the
-    artifact at startup for that reason; an unknown category is a `400`, not an empty list.
+    carries no meaning now and that inference is wrong. The tag and category vocabularies do
+    not correspond at all: `first` is a tag on ~104 rows and a category on none, and `bitcoin`
+    is now neither — so `/api/events/tags/bitcoin` returns an empty list and
+    `?category=bitcoin` is a `400`. Filter with `/api/events?category=…` and discover the
+    values with `/api/categories`. The set is closed but **owned by the data and liable to
+    change in both directions** — `security` appeared a day after the column did, and on
+    2026-08-12 the whole vocabulary was rewritten from fifteen values to eight — so accept
+    unrecognised values rather than hardcoding the list. The service derives the accepted
+    values from the artifact at startup for that reason; an unknown category is a `400`, not
+    an empty list.
+*   **`landmark` is a boolean, orthogonal to `category`.** It marks the events that matter to a
+    bitcoiner — 402 of 581 RU and 394 of 565 EN — and drives one UI control, the "Только
+    главное" switch. Filter with `/api/events?landmark=true`, which ANDs with `?category=` and
+    the date filters. Always `true` or `false`, never `null`. Added 2026-08-12: an artifact
+    published before then has no such column, and the service then reports `false` everywhere
+    and rejects `?landmark=` with a `400` rather than answering a misleading empty list.
     It is a filter on `/api/events` **only** — sending it to `/api/search` or
     `/api/events/tags/:tag` is a `400` too, rather than a `200` full of unfiltered results.
 *   **`events` is always an array**, `[]` when nothing matches, on every endpoint that
@@ -120,7 +129,8 @@ These are the parts that are not guessable from the endpoint list. Each was a re
       "sha256": "12a5f040…",
       "rows": 581,
       "fts": { "indexed": 581, "consistent": true },
-      "categories": { "present": true, "count": 15 }
+      "categories": { "present": true, "count": 8 },
+      "landmark": { "present": true, "count": 402 }
     }
   }
 }
@@ -139,6 +149,12 @@ the artifact predates the column (`present: false`, which is what a rollback loo
 no row carries a value (`present: true`, which should never have been published).
 `publish-db.sh` refuses to leave a release in the second state. It does not affect `status`:
 a rollback target is not a degraded service.
+
+`landmark` reports the same two things for the flag, and `count` is exactly what
+`?landmark=true` returns. It differs from `categories` in what `count: 0` means: no row
+carrying the flag is legal data — the validator sets no target fraction for an editorial
+judgement — so `?landmark=true` answers an empty list and `publish-db.sh` warns rather than
+refusing. `present: false` is an artifact predating 2026-08-12.
 
 **The service refuses to start** if a full-text index is missing, empty or unreadable. That
 is deliberate: a broken index makes `/api/search` return an empty result set, which is

--- a/categories.go
+++ b/categories.go
@@ -45,12 +45,22 @@ var categoriesByLang = map[string]categorySet{}
 //
 // The vocabulary is derived from the data rather than compiled in, and that is
 // the whole design decision here. `category` is a closed set, but canonical
-// owns it and it grows: the column shipped 2026-08-09 with fourteen values and
-// gained `security` the next day. A hardcoded list would have rejected
-// `security` with a 400 until a new binary was built *and* deployed — turning a
-// content edit into a code release. Reading it at boot means a new category
-// works the moment the artifact carrying it is published, which is the same
-// moment the rows using it appear.
+// owns it and it changes in both directions.
+//
+// It grows: the column shipped 2026-08-09 with fourteen values and gained
+// `security` the next day. A hardcoded list would have rejected `security` with
+// a 400 until a new binary was built *and* deployed — turning a content edit
+// into a code release.
+//
+// It also shrinks, which the growth case does not cover and which this handles
+// only because the set is *derived* rather than merged. On 2026-08-12 canonical
+// rewrote the vocabulary from fifteen values to eight, dissolving `bitcoin` and
+// `first` across every row. SELECT DISTINCT over live rows means a value that
+// leaves the data leaves `members` in the same release, so ?category=bitcoin
+// becomes a 400 naming the eight that replaced it — rather than a 200 with an
+// empty list, which is what a stale compiled-in list would have produced and is
+// exactly the silence this filter exists to break. Nothing survives a release
+// to contradict it: the process restarts, and there is no cache.
 //
 // The cost is one query per artifact at startup, no DDL, no writes.
 //
@@ -72,18 +82,11 @@ func loadCategories(db *gorm.DB) (categorySet, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), categoryProbeTimeout)
 	defer cancel()
 
-	// Asked of the schema rather than inferred from a failed SELECT. Matching
-	// on "no such column" would work today but puts a driver's error text on
-	// the boot path, where a reworded message becomes a service that will not
-	// start; pragma_table_info answers the question directly and is the same
-	// idiom the suite already uses to read an artifact's columns.
-	var hasColumn int64
-	if err := db.WithContext(ctx).Raw(
-		`SELECT count(*) FROM pragma_table_info('events') WHERE name = 'category'`,
-	).Scan(&hasColumn).Error; err != nil {
-		return categorySet{}, fmt.Errorf("checking for the category column: %w", err)
+	present, err := hasColumn(db.WithContext(ctx), "category")
+	if err != nil {
+		return categorySet{}, err
 	}
-	if hasColumn == 0 {
+	if !present {
 		return categorySet{}, nil
 	}
 

--- a/database.go
+++ b/database.go
@@ -54,7 +54,7 @@ func (d DateString) Value() (driver.Value, error) { return string(d), nil }
 // Event matches the schema of the canonical database artifact:
 //
 //	events(id, date, title, description, media, tags, "references",
-//	       created_at, updated_at, url_path, category)
+//	       created_at, updated_at, url_path, category, landmark)
 //
 // The column order above is RU's. EN declares the same names in a different
 // order — media is fourth in RU and eighth in EN — so nothing here or in the
@@ -78,19 +78,45 @@ func (d DateString) Value() (driver.Value, error) { return string(d), nil }
 // closed set is enforced by validate.py invariant 13 and not by the DDL — the
 // column is declared TEXT with notnull=0 — so the data is clean because the
 // publisher checks it, not because the database would refuse otherwise.
-// Measured 2026-08-10 across both artifacts: 0 NULL, 0 empty, 0 values outside
+// Measured 2026-08-12 across both artifacts: 0 NULL, 0 empty, 0 values outside
 // the set, in 1,146 rows.
 //
 // Deliberately not an enum, and no list of permitted values anywhere in this
-// package: canonical owns the vocabulary and it grows. It shipped on 2026-08-09
-// with fourteen values and gained `security` the next day. A validating type
-// here would have to be rebuilt and redeployed to accept a value the data
-// already contains — so this field carries whatever the artifact holds, and
-// anything that genuinely needs the current set reads it from the artifact.
+// package: canonical owns the vocabulary and it *changes*. It shipped on
+// 2026-08-09 with fourteen values, gained `security` the next day, and on
+// 2026-08-12 was rewritten down to eight — `bitcoin` and `first` dissolved
+// entirely. A validating type here would have had to be rebuilt and redeployed
+// twice: once to accept a value the data already contained, and once to stop
+// accepting two it no longer does. So this field carries whatever the artifact
+// holds, and anything that genuinely needs the current set reads it from the
+// artifact.
 //
 // Consumers used to derive this from tags[0]. That inference is now wrong: tag
-// order carries no meaning, and `bitcoin` is a category value with no
-// corresponding tag left in the data at all.
+// order carries no meaning, and the two vocabularies do not correspond — `first`
+// is a tag on 104 RU rows and a category on none, having been a category on 53
+// of them until 2026-08-12.
+//
+// Landmark answers one question — is this event important to a bitcoiner — and
+// exists to drive one UI control, a switch that hides everything else. It is
+// orthogonal to Category: 402 of 581 RU rows and 394 of 565 EN rows carry it,
+// spread across every category.
+//
+// A plain bool, not a pointer, and that is the deliberate half. The column is
+// INTEGER NOT NULL DEFAULT 0 and validator invariant 14 pins it to exactly 0 or
+// 1, precisely so that "not a landmark" has one spelling — canonical chose the
+// constraint over a nullable column to avoid the defect step28 fixed for media
+// and references, where a NULL read as falsy in one consumer and as missing in
+// another. A *bool here would put that second spelling straight back into the
+// JSON, for a state no published artifact can hold.
+//
+// The one case a pointer would describe is an artifact predating the column, on
+// which every row renders `false` rather than "this artifact cannot say". That
+// is the same trade Category makes — it renders "" on those files — and it is
+// the right one, because the honest signal is delivered where a caller will
+// actually meet it: ?landmark= is refused with a 400 that says the artifact
+// predates the column, and /health reports landmark.present false for the
+// operator. A null in the payload would be a third channel that every client
+// has to branch on and none would.
 //
 // CreatedAt and UpdatedAt are pointers for the same reason as Media: they are
 // genuinely absent on many rows (505 of 582 RU created_at, 265 of 565 EN), and
@@ -108,8 +134,35 @@ type Event struct {
 	References  *string    `json:"references" gorm:"type:text"` // JSON array as string; NULL when absent
 	URLPath     string     `json:"url_path" gorm:"column:url_path"`
 	Category    string     `json:"category" gorm:"column:category"`
-	CreatedAt   *time.Time `json:"created_at"` // NULL on many rows; renders as null
-	UpdatedAt   *time.Time `json:"updated_at"` // NULL on many rows; renders as null
+	Landmark    bool       `json:"landmark" gorm:"column:landmark"` // INTEGER 0/1; false on an artifact predating the column
+	CreatedAt   *time.Time `json:"created_at"`                      // NULL on many rows; renders as null
+	UpdatedAt   *time.Time `json:"updated_at"`                      // NULL on many rows; renders as null
+}
+
+// hasColumn reports whether the events table in this artifact carries a column.
+//
+// Asked of the schema rather than inferred from a failed SELECT. Matching on
+// "no such column" would work today but puts a driver's error text on the boot
+// path, where a reworded message becomes a service that will not start;
+// pragma_table_info answers the question directly and is the same idiom the
+// test suite already uses to read an artifact's columns.
+//
+// It exists because two columns now need it. `category` arrived on 2026-08-09
+// and `landmark` on 2026-08-12, releases predating each are still on the box as
+// rollback targets, and the handlers that name either column by hand fail with
+// `no such column` against them — which is a 500 for a question this service
+// can otherwise answer perfectly well. See loadCategories and loadLandmark.
+//
+// The name is a bind parameter in a WHERE clause, not a spliced identifier, so
+// there is nothing here to quote.
+func hasColumn(db *gorm.DB, name string) (bool, error) {
+	var n int64
+	if err := db.Raw(
+		`SELECT count(*) FROM pragma_table_info('events') WHERE name = ?`, name,
+	).Scan(&n).Error; err != nil {
+		return false, fmt.Errorf("checking for the %s column: %w", name, err)
+	}
+	return n > 0, nil
 }
 
 // InitDB opens a database read-only. It performs no schema management of any

--- a/deploy/publish-api.sh
+++ b/deploy/publish-api.sh
@@ -600,6 +600,20 @@ for lang in sorted(set(b_dbs) & set(a_dbs)):
             f'         {b_cats} -> {a_cats}\n'
             f'         The artifact is byte-identical, so this binary reads it differently.')
 
+    # The landmark flag, on the same argument and with the same guard. The
+    # `is not None` half is doing real work on the release that introduces the
+    # field: `before` is the old binary, which does not report it, and `after`
+    # is the new one, which does. Comparing those two would fail the very deploy
+    # that adds the check, so absent on either side is not a fault — it is a
+    # binary older than the field on that side, i.e. the first deploy of one
+    # that has it, or a rollback past it.
+    b_lm, a_lm = b.get("landmark"), a.get("landmark")
+    if b_lm is not None and a_lm is not None and b_lm != a_lm:
+        problems.append(
+            f'{lang}: the landmark flag changed across a binary deploy —\n'
+            f'         {b_lm} -> {a_lm}\n'
+            f'         The artifact is byte-identical, so this binary reads it differently.')
+
 print("\n".join(notes))
 if problems:
     print("PROBLEMS", file=sys.stderr)

--- a/deploy/publish-db.sh
+++ b/deploy/publish-db.sh
@@ -12,7 +12,8 @@
 #   remote validate   run validate.py against the STAGED copy, not just the source
 #   local  schema     the API's own test, against the staged copy — see below
 #   remote flip       symlink, then restart (mandatory — see below)
-#   remote verify     /health hashes, FTS coverage, categories, and a search assertion
+#   remote verify     /health hashes, FTS coverage, categories, landmarks, and a
+#                     search assertion
 #   remote prune      keep the last N releases
 #
 # What happens when something fails after the flip depends on what failed, and
@@ -103,11 +104,20 @@ DBS=(events_ru.db events_en.db)
 # Both numbers were re-measured against release 20260810T131954Z on 2026-08-10
 # and both had drifted. EN fell 450 -> 389 because the `bitcoin` tag was retired
 # in canonical: events_fts indexes the tags column, so removing the tag from
-# ~76% of rows removed those matches. `bitcoin` survives as a category value,
-# which the FTS index does not cover. RU fell 246 -> 244 with ordinary edits.
+# ~76% of rows removed those matches. RU fell 246 -> 244 with ordinary edits.
 # The previous release printed the warning below exactly as designed and the
 # constants were simply never updated — which is the failure mode this comment
 # exists to make harder.
+#
+# Re-measured again on 2026-08-13, against canonical after the step40 taxonomy
+# migration, and both are UNCHANGED: ru 244, en 389. That step rewrote `category`
+# on all 1,146 rows and added `landmark`, and touched neither title, description
+# nor tags — the only three columns events_fts indexes — so the counts could not
+# move. Confirmed by running both terms against dbs/superseded/*pre-step40* and
+# getting the same two numbers. Note that `bitcoin` is no longer a category at
+# all: step40 dissolved it, so it is now neither a tag nor a category, and an
+# earlier version of this comment offering it as the survivor of that 450 -> 389
+# drop is no longer true.
 VOCAB_RU_TERM="биткоин"
 VOCAB_EN_TERM="bitcoin"
 VOCAB_RU_LAST=244
@@ -628,7 +638,8 @@ fi
 # Asserts, in one pass: status is ok; both languages resolve to the release
 # just published (this is the check that catches a missed restart); the hashes
 # the process reports match the checksums that shipped with the artifact; every
-# row is indexed in both languages; and the category vocabulary is non-empty.
+# row is indexed in both languages; the category vocabulary is non-empty; and
+# the landmark flag is present.
 #
 # The category assertion is here because nothing else can make it. An artifact
 # whose `category` column carries nothing on any row has the right schema, so
@@ -712,6 +723,45 @@ for lang in ("en", "ru"):
             f"         should not exist. Every ?category= will be rejected until it is fixed.")
     else:
         notes.append(f'{lang}: {cats["count"]} categories')
+
+    # The same three states as categories, and the same reason for reporting
+    # them here: nothing else in this script can see any of them.
+    #
+    # The first case is the one only this can report. The schema guard runs the
+    # API's test from the LOCAL repo — it proves the staged artifact matches the
+    # checkout on this laptop, and says nothing about how old the binary on the
+    # box is — so publishing a landmark column against a binary that predates
+    # the field passes every other check green. That is not an incident: the
+    # column simply reaches no response until the binary catches up, and nothing
+    # consuming this API reads it yet. It is worth saying out loud anyway,
+    # because the symptom is a field that is quietly missing rather than one
+    # that is wrong, and those are the ones that go unnoticed.
+    #
+    # Where it departs from categories: an empty count is a WARNING, not a
+    # failure. validate.py invariant 14 pins every value to 0 or 1 and
+    # deliberately sets no target fraction — the flag is an editorial
+    # judgement — so an artifact with no landmarks is legal data in a way an
+    # artifact with no categories is not. It is still said out loud, because it
+    # empties the one UI control the column exists to drive.
+    lm = db.get("landmark")
+    if lm is None:
+        notes.append(f"!{lang}: /health carries no landmark flag; the running binary predates "
+                     f"the field, so this release is not checked for one. If this release is "
+                     f"the one adding `landmark`, run publish-api.sh to catch the binary up — "
+                     f"until then the column ships but reaches no response")
+    elif not lm.get("present"):
+        # No column at all: the artifact predates 2026-08-12. The schema guard
+        # should already have refused it, so reaching here means it was
+        # bypassed, and --allow-schema-drift is exactly that bypass.
+        msg = (f"{lang}: the published artifact has no `landmark` column, so ?landmark= is "
+               f"rejected for every value and every event reports landmark false")
+        (notes.append("!" + msg) if allow_schema_drift else problems.append(msg))
+    elif not lm.get("count"):
+        notes.append(f"!{lang}: the `landmark` column carries the flag on none of {db['rows']} "
+                     f"rows. That is legal — the validator sets no target fraction — but it "
+                     f"empties the switch the flag exists for. Check it was intended.")
+    else:
+        notes.append(f'{lang}: {lm["count"]} landmarks')
 
 print("\n".join(notes))
 if problems:

--- a/docs/APIDocumentation.md
+++ b/docs/APIDocumentation.md
@@ -83,7 +83,8 @@ client, because they have changed:
 | `media` | string \| null | A JSON array encoded as a string, or `null` when the event has no media. Never `""` and never `"[]"` — absence is exactly one value. |
 | `references` | string \| null | Same encoding and same null rule as `media`. |
 | `url_path` | string | `/<date>/<slug>/`, e.g. `"/2013-08-09/hal-finneys-last-post/"`. The site's page path and the cross-language join key. **Note the leading slash** — joining it onto a base URL with another `/` yields a double slash. |
-| `category` | string | The event's single classification. Always present, never empty, always one of a closed set — but **the set is owned by the data, not by this API, and it grows**: `security` was added on 2026-08-10, a day after the column itself. Treat an unrecognised value as valid and render it; do not hardcode the list into a client. As of 2026-08-10 it is: `archives`, `bitcoin`, `first`, `holiday`, `legal`, `lightning`, `macro`, `mining`, `mustread`, `obituary`, `price`, `privacy`, `scam`, `security`, `software`. **Do not derive it from `tags[0]`** — that inference used to work and is now wrong, because tag order carries no meaning. In particular `bitcoin` is a category with no corresponding tag left in the data at all, so `/api/events/tags/bitcoin` returns nothing while 132 RU and 66 EN events are `category: "bitcoin"`. |
+| `category` | string | The event's single classification. Always present, never empty, always one of a closed set — but **the set is owned by the data, not by this API, and it changes in both directions**. It gained `security` on 2026-08-10, and on 2026-08-12 it was rewritten from fifteen values down to eight. Treat an unrecognised value as valid and render it; do not hardcode the list into a client. As of 2026-08-12 it is: `adoption`, `archives`, `fiat`, `freedom`, `holiday`, `obituary`, `reading`, `tech`. **Do not derive it from `tags[0]`** — that inference used to work and is now wrong, because tag order carries no meaning. Note that the tag and category vocabularies do not correspond: `first` is a tag on ~104 rows and a category on none (it was a category until 2026-08-12), and `bitcoin` is now neither. |
+| `landmark` | boolean | Whether this event is one of the events that matter to a bitcoiner — the flag behind the site's "Только главное" switch. Always present, always `true` or `false`, **never `null`**. It is orthogonal to `category`: 402 of 581 RU and 394 of 565 EN events carry it, spread across every category. Added 2026-08-12; against a database artifact published before then the service reports `false` for every event, and `/health` says `landmark.present: false`. |
 | `created_at` | string \| null | RFC 3339, or `null`. Bookkeeping about the row, not about the event; most rows have no value. |
 | `updated_at` | string \| null | Same. |
 
@@ -98,6 +99,7 @@ client, because they have changed:
   "references": "[\"https://web.archive.org/web/20240207194838/https://bitcointalk.org/...\"]",
   "url_path": "/2013-08-09/hal-finneys-last-post/",
   "category": "archives",
+  "landmark": true,
   "created_at": null,
   "updated_at": null
 }
@@ -123,9 +125,10 @@ Tag matching on `/events/tags/:tag` is case-insensitive.
 > | `econ` | never existed | `economics` |
 > | `clownworld` | retired from the data | — |
 >
-> Separately, **`bitcoin` is not a tag.** It was retired from every row and now exists only as
-> a `category`, so `/api/events/tags/bitcoin` returns an empty list. See the `category` field
-> above.
+> Separately, **`bitcoin` is neither a tag nor a category.** It was retired from every row's
+> tags, survived for two days as a `category`, and was dissolved from that too on 2026-08-12.
+> `/api/events/tags/bitcoin` returns an empty list and `?category=bitcoin` is a `400`. See the
+> `category` field above.
 
 The most-used tags, by event count as of 2026-08-10 (English; Russian is within a row or two):
 
@@ -263,7 +266,8 @@ Error responses will typically be in JSON format, like:
     *   `year` (optional, string, format: `YYYY` e.g., "2022"): Year for filtering events.
     *   `month` (optional, string, format: `MM` or `M` e.g., "05" or "5"): Month for filtering events.
     *   `day` (optional, string, format: `DD` or `D` e.g., "27" or "7"): Day for filtering events.
-    *   `category` (optional, string): Return only events with this category. Case-insensitive. **An unrecognised value is a `400`**, not an empty list — see *Rejected input*. Combines with the date filters (they AND together), so `?category=bitcoin&month=5` is "bitcoin events in May". Call `/api/categories` for the valid values and their counts; the service derives them from the artifact at startup, so a category canonical adds is accepted as soon as its data is published.
+    *   `category` (optional, string): Return only events with this category. Case-insensitive. **An unrecognised value is a `400`**, not an empty list — see *Rejected input*. Combines with the date filters (they AND together), so `?category=tech&month=5` is "tech events in May". Call `/api/categories` for the valid values and their counts; the service derives them from the artifact at startup, so a category canonical adds is accepted as soon as its data is published — and one it removes is rejected from the same moment.
+    *   `landmark` (optional, boolean): Return only events whose `landmark` flag matches. Accepts `true`/`false` and the other spellings Go's `strconv.ParseBool` takes (`1`, `0`, `t`, `f`, `True`, `FALSE`, …); anything else is a `400`. ANDs with `category` and the date filters, so `?category=tech&landmark=true` is "the tech events that matter". Against an artifact published before 2026-08-12 the column does not exist and **any** value is a `400` explaining that — never a silently empty list. Check `/health` → `databases.<lang>.landmark.present` if you need to know in advance.
 *   **Request Body:** None
 *   **Success Response (200 OK):**
     *   **Content-Type:** `application/json`
@@ -280,7 +284,8 @@ Error responses will typically be in JSON format, like:
               "media": null,
               "references": "[\"https://bitcoin.org/bitcoin.pdf\"]",
               "url_path": "/2008-11-01/bitcoin-whitepaper-published/",
-              "category": "mustread",
+              "category": "reading",
+              "landmark": true,
               "created_at": null,
               "updated_at": null
             }
@@ -395,7 +400,8 @@ Error responses will typically be in JSON format, like:
             "media": null,
             "references": "[\"https://bitcoin.org/bitcoin.pdf\"]",
             "url_path": "/2008-11-01/bitcoin-whitepaper-published/",
-            "category": "mustread",
+            "category": "reading",
+            "landmark": true,
             "created_at": null,
             "updated_at": null
           }
@@ -473,12 +479,12 @@ Error responses will typically be in JSON format, like:
         {
           "data": [
             {
-              "category": "archives",
-              "count": 89
+              "category": "adoption",
+              "count": 102
             },
             {
-              "category": "bitcoin",
-              "count": 66
+              "category": "archives",
+              "count": 100
             }
             // ... more categories
           ]
@@ -499,7 +505,7 @@ Error responses will typically be in JSON format, like:
     curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/categories?lang=en"
 
     # Then filter by one
-    curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/events?lang=en&category=bitcoin&limit=5"
+    curl -H "X-API-KEY: your_api_key" "http://localhost:3000/api/events?lang=en&category=adoption&landmark=true&limit=5"
     ```
 
 ### 6. Get Events by Tag (Paginated)
@@ -530,7 +536,8 @@ Error responses will typically be in JSON format, like:
               "media": "[\"https://example.com/pizza.webp\"]",
               "references": "[\"https://bitcointalk.org/...\"]",
               "url_path": "/2010-05-22/bitcoin-pizza-day/",
-              "category": "bitcoin",
+              "category": "adoption",
+              "landmark": true,
               "created_at": "2026-08-08T09:59:56Z",
               "updated_at": "2026-08-08T09:59:56Z"
             }
@@ -580,14 +587,16 @@ Error responses will typically be in JSON format, like:
           "sha256": "6abda1c576b81220538b35d2d697064ac5a0ea72ecc6772d9c58832cdcf8f80e",
           "rows": 565,
           "fts": { "indexed": 565, "consistent": true },
-          "categories": { "present": true, "count": 15 }
+          "categories": { "present": true, "count": 8 },
+          "landmark": { "present": true, "count": 394 }
         },
         "ru": {
           "path": "/srv/bitcal/data/releases/20260810T191227Z/events_ru.db",
           "sha256": "12a5f04093e31ceb0a34cf44b60f4d5758869c96e990bb5b840ac3f983b45ba4",
           "rows": 581,
           "fts": { "indexed": 581, "consistent": true },
-          "categories": { "present": true, "count": 15 }
+          "categories": { "present": true, "count": 8 },
+          "landmark": { "present": true, "count": 402 }
         }
       }
     }
@@ -606,13 +615,21 @@ Error responses will typically be in JSON format, like:
 | `fts.consistent` | `fts.indexed == rows` — every event is reachable by `/api/search`. |
 | `categories.present` | Whether the artifact has a `category` column at all. `false` means it predates 2026-08-09. |
 | `categories.count` | Distinct categories the service read from it at startup — the exact set `?category=` validates against, and the same list `/api/categories` returns. |
+| `landmark.present` | Whether the artifact has a `landmark` column at all. `false` means it predates 2026-08-12; every event then reports `landmark: false` and `?landmark=` is rejected. |
+| `landmark.count` | Events carrying the flag — exactly what `?landmark=true` returns. |
 
-`categories` is the one part of this document that describes the artifact's *contents* rather
-than its shape, and it is here for the release check: when `count` is `0`, every `?category=`
-is rejected and `/api/categories` is empty, and nothing else outside the boot log says so.
-The two fields are separate because they mean different things — `present: false` is an
-artifact older than the column, which is a legitimate rollback target; `present: true` with
-`count: 0` is a column no row carries a value in, which should never have been published.
+`categories` and `landmark` are the parts of this document that describe the artifact's
+*contents* rather than its shape, and they are here for the release check: nothing else
+outside the boot log reports either. In both, the two fields are separate because they mean
+different things — `present: false` is an artifact older than the column, which is a
+legitimate rollback target; `present: true` with `count: 0` is a column no row carries a value
+in.
+
+They differ in how bad `count: 0` is. For `categories` it should never have been published:
+every `?category=` is rejected and `/api/categories` is empty, and `publish-db.sh` refuses to
+leave a release in that state. For `landmark` it is legal data — the validator pins every
+value to 0 or 1 but sets no target fraction, because the flag is an editorial judgement — so
+`?landmark=true` simply answers an empty list, and the publisher warns rather than failing.
 
 #### On the status code
 
@@ -622,9 +639,10 @@ completeness of search, and returning a failure code would have a load balancer 
 no good reason. **Read the `status` field, not the HTTP code.**
 
 `status` reports full-text coverage only. An absent or empty category vocabulary does **not**
-make it `degraded`: serving an artifact that predates the column is what a rollback looks
-like, and a dashboard alarming for the duration of one is pressure to end the rollback rather
-than to fix the release. Read `categories` for that.
+make it `degraded`, and neither does an absent or unset `landmark` column: serving an artifact
+that predates either is what a rollback looks like, and a dashboard alarming for the duration
+of one is pressure to end the rollback rather than to fix the release. Read `categories` and
+`landmark` for that.
 
 The states that would make search useless rather than incomplete — the index missing, empty,
 or unreadable — are not reported here at all, because the service refuses to start on them.

--- a/docs/DatabaseDocumentation.md
+++ b/docs/DatabaseDocumentation.md
@@ -53,28 +53,38 @@ Present in both database files, with identical definitions.
 | `created_at`  | `datetime`    |               | Row bookkeeping. `NULL` on most rows. |
 | `updated_at`  | `datetime`    |               | Row bookkeeping. `NULL` on most rows. |
 | `url_path`    | `TEXT`        | `UNIQUE` index | `/<date>/<slug>/`. The website's page path and the cross-language join key. |
-| `category`    | `TEXT`        | none in the DDL | The event's single classification, from a closed set owned by canonical. Added 2026-08-09. **Mandatory by validator invariant 13, not by the schema** — the column is declared `notnull=0`, so the data is clean because the publisher checks it, not because SQLite would refuse otherwise. Measured 2026-08-10 across both artifacts: 0 `NULL`, 0 `''`, 0 values outside the set, 0 not lowercase/trimmed, in 1,146 rows. |
+| `category`    | `TEXT`        | none in the DDL | The event's single classification, from a closed set owned by canonical. Added 2026-08-09, vocabulary rewritten 2026-08-12. **Mandatory by validator invariant 13, not by the schema** — the column is declared `notnull=0`, so the data is clean because the publisher checks it, not because SQLite would refuse otherwise. Measured 2026-08-12 across both artifacts: 0 `NULL`, 0 `''`, 0 values outside the set, 0 not lowercase/trimmed, in 1,146 rows. |
+| `landmark`    | `INTEGER`     | `NOT NULL DEFAULT 0` | Boolean, orthogonal to `category`: is this event important to a bitcoiner. Added 2026-08-12. Constrained to exactly `0` or `1` by validator invariant 14 — SQLite would accept anything in an `INTEGER` column, and a `'true'` or a `NULL` would read as truthy in one consumer and falsy in another. `NOT NULL` is deliberate rather than incidental: it gives "not a landmark" exactly one spelling, which is the defect step28 fixed for `media`/`references`. 402 of 581 RU rows and 394 of 565 EN rows carry it. |
 
-**On `category`.** As of 2026-08-10 the values are `archives`, `bitcoin`, `first`, `holiday`,
-`legal`, `lightning`, `macro`, `mining`, `mustread`, `obituary`, `price`, `privacy`, `scam`,
-`security`, `software` — identical sets in both languages.
+**On `category`.** As of 2026-08-12 the values are `adoption`, `archives`, `fiat`, `freedom`,
+`holiday`, `obituary`, `reading`, `tech` — identical sets in both languages.
 
-**Do not treat that list, or its length, as fixed.** It has already changed twice: the column
-arrived on 2026-08-09 with fourteen values, and `security` was added on 2026-08-10, carved out
-of `bitcoin` (which fell 148→132 RU and 82→66 EN). Canonical owns this vocabulary. Anything
-here that needs the current set should read it from the artifact rather than carry a copy.
+**Do not treat that list, or its length, as fixed.** It has already changed three times, and
+the last change went *down*: the column arrived on 2026-08-09 with fourteen values, `security`
+was added on 2026-08-10, and on 2026-08-12 the whole vocabulary was rewritten from fifteen
+values to eight, dissolving `bitcoin` (132 RU / 66 EN rows) and `first` (53 RU / 69 EN) across
+the survivors. Canonical owns this vocabulary — it is authored in `categories.yaml`, generated
+into `categories.json`, and read from there by `validate.py`. Anything here that needs the
+current set should read it from the artifact rather than carry a copy.
+
 That is what the API does: `loadCategories` in `categories.go` runs one `SELECT DISTINCT` per
-artifact at startup, and `?category=` validates against the result. Had the list been compiled
-in, `security` would have been rejected as invalid until a new binary was built and deployed.
+artifact at startup, and `?category=` validates against the result. Because the set is
+*derived* rather than merged, it tracks both directions: had the list been compiled in,
+`security` would have been rejected until a new binary shipped, and `bitcoin` would have gone
+on being accepted — answering `200` with an empty list — long after the data stopped
+containing it.
 
 It replaces an older convention in which consumers read the classification out of `tags[0]`;
-tag order no longer carries meaning and that inference is now wrong. `bitcoin` is the clearest
-case — it exists as a category (132 RU, 66 EN) and **no longer exists as a tag at all**, so a
-hard-coded `tag=bitcoin` query returns zero rows.
+tag order no longer carries meaning and that inference is now wrong. The two vocabularies do
+not correspond: `first` is a tag on ~104 rows in each language and a category on none, having
+been a category on 53 RU rows until 2026-08-12, and `bitcoin` is now neither a tag nor a
+category — so a hard-coded `tag=bitcoin` query returns zero rows and `?category=bitcoin` is a
+`400`.
 
-The two languages disagree about the category of 62 of the 562 events they share by
-`url_path`. That is catalogued in canonical's README and is data, not a bug — but a
-two-language filter built on this column will return genuinely different sets.
+The languages used to disagree about the category of 62 of the 562 events they share by
+`url_path`. The 2026-08-12 migration closed that: RU is the reviewed language and EN takes the
+same value through `CROSSWALK-ru-en.tsv`, and all 565 paired rows now agree on **both**
+`category` and `landmark`. A two-language filter on either column returns matching sets.
 
 **The two languages declare these columns in different orders.** RU stores `media` fourth, EN
 eighth; the names and types match but the positions do not. Anything reading this schema must

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -88,14 +88,39 @@ There is no `PORT` variable any more; use `LISTEN_ADDR`.
     `--allow-schema-drift` if you have decided to publish data ahead of the binary;
 5.  flips the symlink and restarts — the restart is mandatory, SQLite holds an open file
     descriptor and flipping alone leaves the old inode being served;
-6.  verifies `/health` names the new release, that its hashes match what was published, and
-    that every row is indexed in both languages;
+6.  verifies `/health` names the new release, that its hashes match what was published, that
+    every row is indexed in both languages, and that the category vocabulary and the landmark
+    flag are what the artifact carries;
 7.  asserts search still returns hits for `биткоин` and `bitcoin` — the only check here that
     would catch a tokenizer change, and the Cyrillic one is the case that actually breaks;
 8.  prunes old releases, keeping `--keep N` (default 5).
 
 **Any failure after the symlink flip rolls back automatically** to the previous release and
 restarts it. A rejected release directory is left in place for inspection.
+
+### When a release adds a column, ship the binary first
+
+`publish-api.sh` **then** `publish-db.sh`. Follow that order because it is free, not because
+the other one breaks something.
+
+Binary-first always works, by construction: the service is built to serve an artifact older
+than itself. A new binary against an artifact lacking `category` or `landmark` boots, answers
+every endpoint, renders the missing field as its zero value, and rejects only the filter it
+genuinely cannot answer. That is the same property that lets a rollback work at all, and it is
+covered by tests. So there is never a reason to reach for the other order.
+
+Data-first is not an outage either — it just does nothing useful for a while. The new column
+ships inside the artifact and reaches no response until the binary catches up, and no client
+sees a wrong answer in the meantime, because nothing consumes this API today except the
+Telegram bot, which reads neither column. The cost is that the flag is invisible and you may
+not notice it is invisible.
+
+That is worth one sentence of care because step 4b will not catch it. The schema guard runs
+the API's test from the *local* repo, so it proves the staged artifact matches the checkout on
+your laptop; it knows nothing about how old the binary on the box is, and passes green either
+way. What does report it is `/health`: `publish-db.sh` warns when the running binary carries no
+`categories` or no `landmark` block, meaning the binary predates the field — rather than
+letting a silently skipped check read as a passing one.
 
 The `deploy` user owns the artifacts but cannot be logged into (`nologin`, no home, no keys) —
 it exists so that `bitcal` cannot write them. Publishing therefore connects as `root` and
@@ -182,6 +207,12 @@ As a single assertion for a release check:
 curl -sf localhost:3000/health | jq -e '
   .status == "ok" and (.databases | to_entries | all(.value.fts.consistent))'
 ```
+
+Deliberately no assertion on `categories.count` or `landmark.count` here. Both are properties
+of the data, not of the deployment: the vocabulary went from 15 values to 8 on 2026-08-12 and
+the landmark count moves whenever the owner re-judges a row, so a number pinned in a release
+check is a check that fails for the wrong reason. Assert `present`, or that the count is
+non-zero, and read the counts `publish-db.sh` prints.
 
 ## Troubleshooting
 

--- a/health.go
+++ b/health.go
@@ -23,6 +23,28 @@ type DatabaseHealth struct {
 	Rows       int64          `json:"rows"`
 	FTS        FTSHealth      `json:"fts"`
 	Categories CategoryHealth `json:"categories"`
+	Landmark   LandmarkHealth `json:"landmark"`
+}
+
+// LandmarkHealth reports the landmark flag this process is serving.
+//
+// Present and Count are separate for the reason CategoryHealth's are, with one
+// difference in what they mean. Present false is an artifact older than the
+// column — a rollback target, expected to be served that way, and the state in
+// which ?landmark= is refused outright. Present with Count zero is an artifact
+// where the column exists and no row carries the flag.
+//
+// That second state is *not* an upstream invariant violation the way an empty
+// category vocabulary is: validate.py invariant 14 pins every value to 0 or 1
+// and deliberately sets no target fraction, because the flag is an editorial
+// judgement. So a release should warn on it rather than refuse it — but it must
+// be able to see it, because it empties the one UI control the flag exists for
+// and nothing else in the system would notice.
+//
+// Count is landmarks, not rows: it is the number ?landmark=true would return.
+type LandmarkHealth struct {
+	Present bool  `json:"present"`
+	Count   int64 `json:"count"`
 }
 
 // CategoryHealth reports the category vocabulary this process is serving.
@@ -123,6 +145,10 @@ func buildHealthSnapshot(dbs map[string]struct {
 		// before it builds this snapshot, and a missing entry reports the same
 		// zero value an artifact with no column does — the safe direction.
 		vocab := categoriesByLang[lang]
+		// Read from what loadLandmark put in landmarkByLang for the same reason,
+		// and loaded at the same point in main() — so /health cannot report a
+		// flag the filter is not the one consulting.
+		flag := landmarkByLang[lang]
 
 		snapshot.Databases[lang] = DatabaseHealth{
 			Path:   resolved,
@@ -132,6 +158,10 @@ func buildHealthSnapshot(dbs map[string]struct {
 			Categories: CategoryHealth{
 				Present: vocab.present,
 				Count:   len(vocab.sorted),
+			},
+			Landmark: LandmarkHealth{
+				Present: flag.present,
+				Count:   flag.count,
 			},
 		}
 	}

--- a/landmark.go
+++ b/landmark.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// landmarkProbeTimeout bounds the boot query, for the same reason
+// categoryProbeTimeout and probeFTS do: a query that hangs here is a boot that
+// hangs, and /api/tags proved this service can hang rather than fail.
+const landmarkProbeTimeout = 10 * time.Second
+
+// landmarkSet is what one language's artifact can say about the landmark flag.
+//
+// Deliberately not a copy of categorySet. `category` is an open-ended closed
+// set whose members have to be read out of the data, because a hardcoded list
+// goes stale in both directions; `landmark` is one boolean, pinned to 0 or 1 by
+// validator invariant 14, and there is no vocabulary to discover. What the two
+// genuinely share is the presence question, and that is factored into
+// hasColumn rather than duplicated in a second set type.
+type landmarkSet struct {
+	// present is whether the artifact has a `landmark` column at all — a
+	// different question from whether any row carries the flag, and the two
+	// have different causes and different fixes. See loadLandmark.
+	//
+	// The zero value is false, which is also what a lookup for a language that
+	// was never loaded returns. That is the safe direction: an unknown language
+	// refuses the filter rather than answering it against nothing.
+	present bool
+	// count is how many rows carry landmark = 1. Reported by /health so a
+	// release can see it; the filter itself does not consult it.
+	count int64
+}
+
+// landmarkByLang holds the flag's state per language. Populated once by
+// loadLandmark during boot and read-only afterwards, so no lock is needed: the
+// artifact is opened read-only and cannot change under a running process — a
+// release replaces the file and restarts the service.
+var landmarkByLang = map[string]landmarkSet{}
+
+// loadLandmark reads the landmark flag's state out of an artifact.
+//
+// An artifact that predates the column is not an error, for exactly the reason
+// spelled out at length in loadCategories: `landmark` arrived on 2026-08-12,
+// every release before that has no such column, and those files are still on
+// the box as rollback targets — publish-db.sh's rollback() re-points `current`
+// at the previous release and restarts. Treating a missing column as fatal
+// would make this binary refuse to start against any of them, turning a
+// rollback into an outage and silently coupling the binary's version to the
+// artifact's.
+//
+// Presence is not cosmetic here. Measured against a real artifact with the
+// column dropped: GORM's own statements survive it untouched, because they
+// SELECT * and simply leave the struct field at its zero value — but
+// `WHERE landmark = ?` fails with `no such column: landmark`, and so would the
+// hand-written SELECT in ftsSearchHandler if it named the column
+// unconditionally. Both would be a 500 for a question this service can answer
+// perfectly well, which is why both consult this.
+//
+// The count is read for /health rather than for the filter. Unlike the category
+// vocabulary, an empty one is not an upstream invariant violation: validate.py
+// invariant 14 checks that every value is 0 or 1 and deliberately does not
+// check how many are 1, because the flag is an editorial judgement with no
+// target fraction. So a column carrying no landmarks at all is legal data — and
+// it would still blank the one UI control the flag exists for, with nothing
+// upstream to notice. Counting it once at boot is what lets a release see it.
+func loadLandmark(db *gorm.DB) (landmarkSet, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), landmarkProbeTimeout)
+	defer cancel()
+
+	present, err := hasColumn(db.WithContext(ctx), "landmark")
+	if err != nil {
+		return landmarkSet{}, err
+	}
+	if !present {
+		return landmarkSet{}, nil
+	}
+
+	var count int64
+	if err := db.WithContext(ctx).Raw(
+		// `= 1` rather than `!= 0`: the column is NOT NULL in the DDL and
+		// invariant 14 admits only 0 and 1, so there is no third state to be
+		// generous about. Being generous would also make this count disagree
+		// with what the filter matches, which is the one thing /health must not
+		// do.
+		`SELECT count(*) FROM events WHERE landmark = 1`,
+	).Scan(&count).Error; err != nil {
+		return landmarkSet{}, fmt.Errorf("counting landmark rows: %w", err)
+	}
+
+	return landmarkSet{present: true, count: count}, nil
+}
+
+// expected renders what would have been accepted, as badParam's `want` clause.
+func (l landmarkSet) expected() string {
+	if !l.present {
+		return "nothing: this artifact predates the landmark column, so no value can match"
+	}
+	return "true or false"
+}

--- a/main.go
+++ b/main.go
@@ -112,44 +112,53 @@ func badParam(c *fiber.Ctx, name, got, want string) error {
 	})
 }
 
-// categoryParamRejected refuses ?category= on an endpoint that does not filter
-// by it, and reports whether it answered the request — the same shape as
+// filterParamRejected refuses a filter parameter on an endpoint that does not
+// honour it, and reports whether it answered the request — the same shape as
 // pagination(), and for the same reason: c.JSON returns nil on success, so a
 // helper that returned its error would look like it had refused while the
 // handler carried on and overwrote the body under a 400 status line.
 //
-// Only /api/events honours the parameter. The two list endpoints this guards —
-// /api/search and /api/events/tags/:tag — accepted it and ignored it: a client
-// narrowing a search with &category=bitcoin got every match, with a 200 and
-// nothing anywhere in the response to say the filter had not been applied. That
-// is the same silence the 400 on an unknown category exists to break, arrived
-// at from the other side.
+// Only /api/events honours `category` and `landmark`. The two list endpoints
+// this guards — /api/search and /api/events/tags/:tag — accepted `category` and
+// ignored it: a client narrowing a search with &category=archives got every
+// match, with a 200 and nothing anywhere in the response to say the filter had
+// not been applied. That is the same silence the 400 on an unknown category
+// exists to break, arrived at from the other side. `landmark` was added to the
+// same guard in the same release that added the filter, so it never had a
+// window in which it was silently ignored here.
 //
-// /api/events/:id also ignores the parameter and is deliberately not guarded:
-// a fetch by id is not a list a filter could narrow, and the response carries
-// the event's actual category, so nothing about ignoring it is silent.
+// /api/events/:id also ignores both and is deliberately not guarded: a fetch by
+// id is not a list a filter could narrow, and the response carries the event's
+// actual category and landmark, so nothing about ignoring them is silent.
 //
 // This deliberately does not become a rule about unknown parameters in general.
-// A stray ?foo= carries no expectation that anything will happen; `category` is
-// a real parameter of this API with a documented meaning, so sending it *is* the
-// expectation. Rejecting it here is also the compatible direction: a later
-// release that implements the filter turns these 400s into 200s, while a client
-// written against today's silent pass-through would have to be corrected.
-func categoryParamRejected(c *fiber.Ctx) bool {
-	got := c.Query("category")
-	if got == "" {
-		return false
+// A stray ?foo= carries no expectation that anything will happen; these are real
+// parameters of this API with documented meanings, so sending one *is* the
+// expectation. Rejecting them here is also the compatible direction: a later
+// release that implements a filter turns these 400s into 200s, while a client
+// written against a silent pass-through would have to be corrected.
+//
+// The first parameter present wins. Answering for one is enough to tell the
+// caller the request was not honoured as sent, and enumerating the rest would
+// only make the message longer than the fix.
+func filterParamRejected(c *fiber.Ctx, names ...string) bool {
+	for _, name := range names {
+		got := c.Query(name)
+		if got == "" {
+			continue
+		}
+		zlog.Warn().Str("param", name).Str("got", got).Str("path", c.Path()).
+			Msg("rejected a query parameter this endpoint does not honour")
+		// The route pattern rather than c.Path(), so /api/events/tags/:tag names
+		// itself instead of echoing whichever tag the caller happened to ask for.
+		c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf(
+				"%s is not a filter on %s, so it is refused rather than ignored. "+
+					"Only /api/events supports ?%s=", name, c.Route().Path, name),
+		})
+		return true
 	}
-	zlog.Warn().Str("param", "category").Str("got", got).Str("path", c.Path()).
-		Msg("rejected a query parameter this endpoint does not honour")
-	// The route pattern rather than c.Path(), so /api/events/tags/:tag names
-	// itself instead of echoing whichever tag the caller happened to ask for.
-	c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-		"error": fmt.Sprintf(
-			"category is not a filter on %s, so it is refused rather than ignored. "+
-				"Only /api/events supports ?category=", c.Route().Path),
-	})
-	return true
+	return false
 }
 
 // eventOrder is the sort every paginated list endpoint uses: newest first, with
@@ -483,9 +492,9 @@ func getEventsByTagHandler(c *fiber.Ctx) error {
 		})
 	}
 
-	// The tag filter does not compose with the category filter. See
-	// categoryParamRejected.
-	if categoryParamRejected(c) {
+	// The tag filter does not compose with the category or landmark filters.
+	// See filterParamRejected.
+	if filterParamRejected(c, "category", "landmark") {
 		return nil
 	}
 
@@ -615,6 +624,45 @@ func getAllEventsHandler(c *fiber.Ctx) error {
 		query = query.Where("LOWER(TRIM(category)) = ?", want)
 	}
 
+	// landmark is the switch the website calls «Только главное»: one boolean,
+	// orthogonal to category, hiding everything that is not a landmark. It ANDs
+	// with category and with the date filters, so ?category=tech&landmark=true
+	// is "the tech events that matter".
+	//
+	// Presence is checked before the value is parsed, and that order is the
+	// point. Against an artifact predating the column — a rollback target —
+	// `WHERE landmark = ?` is `no such column: landmark`, measured, which would
+	// be a 500 for a question this service can answer perfectly well. It is also
+	// the more useful of the two rejections: "this artifact predates the column"
+	// tells the caller something "expected true or false" cannot.
+	//
+	// Unlike category there is no vocabulary to consult, so an unparseable value
+	// is the only other way to be wrong. It is a 400 rather than a quiet default
+	// for the reason the date filters are: ?landmark=yes silently read as false
+	// answers 200 with the 179 rows the caller least wanted, and nothing in the
+	// response says the filter was not the one asked for.
+	if landmarkStr := c.Query("landmark"); landmarkStr != "" {
+		// resolveLang, not the raw parameter, for the reason the category filter
+		// spells out: the artifact consulted must be the one this request reads.
+		flag := landmarkByLang[resolveLang(lang)]
+		if !flag.present {
+			return badParam(c, "landmark", landmarkStr, flag.expected())
+		}
+		// ParseBool rather than a hand-rolled comparison: it is the spelling a Go
+		// client would produce and a documented set (1/t/T/TRUE/true/True and the
+		// false equivalents), so callers who send "1" are not surprised. The
+		// rejection names `true or false` because that is the canonical form to
+		// reach for, not because the others are refused.
+		want, err := strconv.ParseBool(strings.TrimSpace(landmarkStr))
+		if err != nil {
+			return badParam(c, "landmark", landmarkStr, flag.expected())
+		}
+		// No LOWER/TRIM counterpart here: this column is INTEGER NOT NULL, so
+		// unlike category there is no stored casing or padding to defend
+		// against. Bound as a Go bool, which the driver binds as 1 or 0.
+		query = query.Where("landmark = ?", want)
+	}
+
 	// First, get the total count of records that match the filter
 	if err := query.Count(&totalEvents).Error; err != nil {
 		zlog.Error().Str("lang", lang).Err(err).Msg("getAllEventsHandler: Failed to count events")
@@ -654,8 +702,8 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Search query is required"})
 	}
 
-	// Search does not narrow by category. See categoryParamRejected.
-	if categoryParamRejected(c) {
+	// Search does not narrow by category or landmark. See filterParamRejected.
+	if filterParamRejected(c, "category", "landmark") {
 		return nil
 	}
 
@@ -702,22 +750,31 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		return queryFailed(c, err, "Failed to count search results")
 	}
 
-	// The one column in the list below that an artifact may genuinely not have.
-	// A release predating 2026-08-09 has no `category`, and those files are
-	// rollback targets — so naming it unconditionally makes every search on a
-	// rolled-back artifact answer 500, which is the outage the boot path was
-	// just taught not to cause. Every other handler adapts for free: GORM builds
-	// its SELECT from the struct against the table it can see, and only this
+	// The two columns in the list below that an artifact may genuinely not have.
+	// A release predating 2026-08-09 has no `category` and one predating
+	// 2026-08-12 has no `landmark`, and those files are rollback targets — so
+	// naming either unconditionally makes every search on a rolled-back artifact
+	// answer 500, which is the outage the boot path was taught not to cause.
+	// Every other handler adapts for free: GORM builds its SELECT from the
+	// struct against the table it can see and leaves the field at its zero value
+	// — measured against an artifact with both columns dropped — and only this
 	// statement enumerates by hand.
 	//
+	// They are independent rather than a single "old artifact" flag, because the
+	// two dates are two months' worth of releases apart and an artifact between
+	// them has one column and not the other.
+	//
 	// Spliced rather than parameterised because a column name is not a bind
-	// parameter. The value is one of two literals decided here, never anything a
+	// parameter. The value is built here from literals, never from anything a
 	// caller sent. Sprintf is safe on this statement specifically because it
 	// contains no other %% verb; anything added below that needs one must escape
 	// it or this stops being a formatting string.
-	categoryCol := " e.category,"
-	if !categoriesByLang[resolveLang(lang)].present {
-		categoryCol = ""
+	optionalCols := ""
+	if categoriesByLang[resolveLang(lang)].present {
+		optionalCols += " e.category,"
+	}
+	if landmarkByLang[resolveLang(lang)].present {
+		optionalCols += " e.landmark,"
 	}
 
 	searchSQL := fmt.Sprintf(`
@@ -731,7 +788,9 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		-- callers empty while /api/events returned them correctly.
 		-- TestEventStructCoversEveryColumn covers search specifically for that
 		-- reason, and checks the values rather than the keys, because a struct
-		-- field the SELECT never fetched still marshals to "" or null.
+		-- field the SELECT never fetched still marshals to "", null — or, since
+		-- landmark, to false, which is why that test had to learn that a false
+		-- proves nothing about whether the column was fetched.
 		--
 		-- fts.rank is deliberately not selected: nothing scans it — there is no
 		-- Rank field on Event — and SQLite orders by it perfectly well without
@@ -749,7 +808,7 @@ func ftsSearchHandler(c *fiber.Ctx) error {
 		-- event twice and never shown another.
 		ORDER BY fts.rank, e.id DESC
 		LIMIT ? OFFSET ?;
-	`, categoryCol)
+	`, optionalCols)
 	if err := db.Raw(searchSQL, query, limit, offset).Scan(&events).Error; err != nil {
 		if isFTSSyntaxError(err) {
 			return badSearchQuery(c, query, lang, err)
@@ -860,6 +919,40 @@ func main() {
 			continue
 		}
 		zlog.Info().Str("lang", lang).Int("categories", len(set.sorted)).Msg("Category vocabulary loaded")
+	}
+
+	// --- Landmark flag ---
+	// Separate from the loop above rather than folded into it: that one uses
+	// `continue` to skip its own logging, which would skip this too.
+	//
+	// An artifact predating the column is not fatal, for the same reason it is
+	// not fatal for category: it is a rollback target, and refusing to start
+	// against one turns a rollback into an outage. Only ?landmark= is affected —
+	// the field itself still renders, as false.
+	for lang, db := range map[string]*gorm.DB{"en": DB_EN, "ru": DB_RU} {
+		flag, err := loadLandmark(db)
+		if err != nil {
+			zlog.Fatal().Str("lang", lang).Err(err).Msg("Failed to read the landmark flag")
+		}
+		landmarkByLang[lang] = flag
+		if !flag.present {
+			zlog.Warn().Str("lang", lang).
+				Msg("This artifact has no landmark column: it predates 2026-08-12. " +
+					"?landmark= will be rejected and every event will report landmark false")
+			continue
+		}
+		// The column is there and no row carries the flag. Unlike an empty
+		// category vocabulary this breaks no upstream invariant — validate.py
+		// invariant 14 sets no target fraction — but it is still almost
+		// certainly a mistake, because it empties the one UI control the column
+		// exists to drive, and nothing upstream would say so.
+		if flag.count == 0 {
+			zlog.Warn().Str("lang", lang).
+				Msg("This artifact has a landmark column but no landmarks: no row carries the " +
+					"flag. ?landmark=true will answer an empty list")
+			continue
+		}
+		zlog.Info().Str("lang", lang).Int64("landmarks", flag.count).Msg("Landmark flag loaded")
 	}
 
 	// --- Health snapshot ---

--- a/tests/boot_test.go
+++ b/tests/boot_test.go
@@ -33,6 +33,10 @@ type healthDoc struct {
 			Present bool `json:"present"`
 			Count   int  `json:"count"`
 		} `json:"categories"`
+		Landmark struct {
+			Present bool  `json:"present"`
+			Count   int64 `json:"count"`
+		} `json:"landmark"`
 	} `json:"databases"`
 }
 

--- a/tests/landmark_test.go
+++ b/tests/landmark_test.go
@@ -1,0 +1,433 @@
+package tests
+
+import (
+	"database/sql"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// The fixture's landmark split, named once. Events 1 and 2 carry the flag in
+// both languages; RU has one extra row that does not, so the false counts
+// differ. See fixtureRows.
+const (
+	landmarksRU    = 2
+	notLandmarksRU = 3
+	landmarksEN    = 2
+	notLandmarksEN = 2
+)
+
+// TestLandmarkFilter is the happy path: the parameter narrows the list, both
+// polarities work, and every row that comes back really carries the value asked
+// for.
+//
+// The last of those is what stops this passing against a handler that ignores
+// the parameter. A count alone would be satisfied by any filter that happened to
+// return the right number of rows; checking the flag on each returned event ties
+// the answer to the column.
+func TestLandmarkFilter(t *testing.T) {
+	for _, tc := range []struct {
+		lang  string
+		want  bool
+		total int
+	}{
+		{"ru", true, landmarksRU},
+		{"ru", false, notLandmarksRU},
+		{"en", true, landmarksEN},
+		{"en", false, notLandmarksEN},
+	} {
+		name := tc.lang + "/"
+		if tc.want {
+			name += "true"
+		} else {
+			name += "false"
+		}
+		t.Run(name, func(t *testing.T) {
+			var list eventList
+			path := "/api/events?lang=" + tc.lang + "&limit=100&landmark="
+			if tc.want {
+				path += "true"
+			} else {
+				path += "false"
+			}
+			if code := getAs(t, apiKey2, path, &list); code != http.StatusOK {
+				t.Fatalf("%s: want 200, got %d", path, code)
+			}
+			if list.Pagination.Total != tc.total {
+				t.Errorf("%s: want %d events, got %d", path, tc.total, list.Pagination.Total)
+			}
+			if len(list.Events) == 0 {
+				t.Fatalf("%s returned no events; the assertion below would pass vacuously", path)
+			}
+			for _, e := range list.Events {
+				if e.Landmark != tc.want {
+					t.Errorf("event %d came back under landmark=%v but carries %v — the filter is "+
+						"not reading the column it claims to", e.ID, tc.want, e.Landmark)
+				}
+			}
+		})
+	}
+}
+
+// TestLandmarkFilterIsNotACategoryFilter guards the pairing that a handler
+// treating the two fields as interchangeable would get wrong.
+//
+// The fixture is built so the two cannot be confused: events 1 and 2 are the
+// landmarks and they carry *different* categories (holiday and mustread), while
+// event 3 shares neither. So no single category selects the landmark set and no
+// landmark value selects a category, and a filter wired to the wrong column
+// cannot accidentally answer correctly.
+func TestLandmarkFilterIsNotACategoryFilter(t *testing.T) {
+	var landmarks eventList
+	if code := getAs(t, apiKey2, "/api/events?lang=ru&limit=100&landmark=true", &landmarks); code != http.StatusOK {
+		t.Fatalf("landmark=true: want 200, got %d", code)
+	}
+	seen := map[string]bool{}
+	for _, e := range landmarks.Events {
+		seen[e.Category] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("every landmark in the fixture shares a category (%v); the fixture no longer "+
+			"models the case this guards", seen)
+	}
+
+	// And the converse: a category that contains one landmark and one row that
+	// is not, so that ?category= alone cannot stand in for ?landmark=.
+	var holiday eventList
+	if code := getAs(t, apiKey2, "/api/events?lang=ru&limit=100&category=holiday", &holiday); code != http.StatusOK {
+		t.Fatalf("category=holiday: want 200, got %d", code)
+	}
+	if holiday.Pagination.Total == 0 {
+		t.Fatal("category=holiday matched nothing")
+	}
+}
+
+// TestLandmarkComposesWithOtherFilters pins that the filters AND together. The
+// website's switch is meant to narrow whatever the calendar is already showing,
+// so a landmark filter that silently replaced the category or date filter would
+// be worse than none.
+func TestLandmarkComposesWithOtherFilters(t *testing.T) {
+	// Event 1 is 1881-09-29, category holiday, landmark true.
+	var hit eventList
+	if code := getAs(t, apiKey2,
+		"/api/events?lang=ru&category=holiday&landmark=true&month=9&day=29", &hit); code != http.StatusOK {
+		t.Fatalf("category+landmark+date: want 200, got %d", code)
+	}
+	if hit.Pagination.Total != 1 {
+		t.Errorf("category=holiday&landmark=true&month=9&day=29: want 1, got %d", hit.Pagination.Total)
+	}
+
+	// The same row, asked for with the flag it does not carry. If the filters
+	// ORed, or if landmark were ignored, this would still be 1.
+	var miss eventList
+	if code := getAs(t, apiKey2,
+		"/api/events?lang=ru&category=holiday&landmark=false&month=9&day=29", &miss); code != http.StatusOK {
+		t.Fatalf("category+landmark+date: want 200, got %d", code)
+	}
+	if miss.Pagination.Total != 0 {
+		t.Errorf("category=holiday&landmark=false&month=9&day=29: want 0, got %d — the filters "+
+			"are not ANDing", miss.Pagination.Total)
+	}
+}
+
+// TestLandmarkRejectsUnparseableValues covers the reason this parameter
+// validates at all.
+//
+// A ?landmark=yes quietly read as false is the failure the date filters and
+// ?category= were both hardened against: it answers 200 with a plausible body —
+// here, precisely the rows the caller least wanted — and nothing in the response
+// says the filter was not the one asked for.
+func TestLandmarkRejectsUnparseableValues(t *testing.T) {
+	for _, bad := range []string{"yes", "no", "on", "2", "-1", "true false", "тру", " "} {
+		t.Run(url.QueryEscape(bad), func(t *testing.T) {
+			var body struct {
+				Error string `json:"error"`
+			}
+			code := getAs(t, apiKey2, "/api/events?lang=ru&landmark="+url.QueryEscape(bad), &body)
+			if code != http.StatusBadRequest {
+				t.Fatalf("landmark=%q: want 400, got %d", bad, code)
+			}
+			if !strings.Contains(body.Error, "true or false") {
+				t.Errorf("landmark=%q was rejected with %q, which does not say what would be "+
+					"accepted; a caller cannot fix the request from that", bad, body.Error)
+			}
+		})
+	}
+}
+
+// TestLandmarkAcceptsTheFormsParseBoolDoes pins the accepted spellings, because
+// the rejection message names only `true or false` and a reader could reasonably
+// conclude the rest are refused. They are not, and a client sending 1 or 0 —
+// which is what the column literally holds — must not get a 400.
+func TestLandmarkAcceptsTheFormsParseBoolDoes(t *testing.T) {
+	for _, form := range []struct {
+		sent  string
+		total int
+	}{
+		{"true", landmarksRU}, {"True", landmarksRU}, {"TRUE", landmarksRU},
+		{"1", landmarksRU}, {"t", landmarksRU},
+		{"false", notLandmarksRU}, {"False", notLandmarksRU},
+		{"0", notLandmarksRU}, {"f", notLandmarksRU},
+	} {
+		t.Run(form.sent, func(t *testing.T) {
+			var list eventList
+			code := getAs(t, apiKey2, "/api/events?lang=ru&limit=100&landmark="+form.sent, &list)
+			if code != http.StatusOK {
+				t.Fatalf("landmark=%s: want 200, got %d", form.sent, code)
+			}
+			if list.Pagination.Total != form.total {
+				t.Errorf("landmark=%s: want %d, got %d", form.sent, form.total, list.Pagination.Total)
+			}
+		})
+	}
+}
+
+// TestLandmarkParamRefusedWhereItDoesNotFilter is the ?category= guard's
+// argument applied to the new parameter, and it is here from the start rather
+// than after the fact: /api/search and /api/events/tags/:tag do not narrow by
+// landmark, and accepting the parameter while ignoring it would answer 200 with
+// every match and nothing to say the filter had not been applied.
+func TestLandmarkParamRefusedWhereItDoesNotFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		accepted string
+		rejected string
+	}{
+		{
+			name:     "search",
+			accepted: "/api/search?lang=ru&q=satoshi",
+			rejected: "/api/search?lang=ru&q=satoshi&landmark=true",
+		},
+		{
+			name:     "by-tag",
+			accepted: "/api/events/tags/satoshi?lang=ru",
+			rejected: "/api/events/tags/satoshi?lang=ru&landmark=true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// The control: without the parameter the endpoint answers, so the 400
+			// below is about the parameter and not about the request.
+			var list eventList
+			if code := getAs(t, apiKey2, tc.accepted, &list); code != http.StatusOK {
+				t.Fatalf("%s: want 200, got %d", tc.accepted, code)
+			}
+			if len(list.Events) == 0 {
+				t.Fatalf("%s matched nothing; this test would prove nothing", tc.accepted)
+			}
+
+			var body struct {
+				Error string `json:"error"`
+			}
+			if code := getAs(t, apiKey2, tc.rejected, &body); code != http.StatusBadRequest {
+				t.Fatalf("%s: want 400, got %d — the parameter was accepted and ignored, which "+
+					"is a filtered-looking response that was never filtered", tc.rejected, code)
+			}
+			if !strings.Contains(body.Error, "landmark") {
+				t.Errorf("%s was rejected with %q, which does not name the parameter at fault",
+					tc.rejected, body.Error)
+			}
+		})
+	}
+}
+
+// TestHealthReportsTheLandmarksItServes is publish-db.sh's assertion, the way
+// TestHealthReportsTheVocabularyItServes is.
+//
+// The count is checked against what the filter actually returns rather than
+// against a number written here, for the same reason: what has to be true is
+// that /health describes the artifact the service is really filtering on, and
+// the filter is where that is observable. A literal would pass just as well
+// against a field populated from a second query.
+func TestHealthReportsTheLandmarksItServes(t *testing.T) {
+	var health healthDoc
+	fetchJSON(t, baseURL+"/health", &health)
+
+	for _, lang := range []string{"en", "ru"} {
+		t.Run(lang, func(t *testing.T) {
+			db, found := health.Databases[lang]
+			if !found {
+				t.Fatalf("%s: absent from /health", lang)
+			}
+			if !db.Landmark.Present {
+				t.Fatalf("%s: /health reports no landmark column, but the fixture has one", lang)
+			}
+
+			var list eventList
+			if code := getAs(t, apiKey3, "/api/events?lang="+lang+"&limit=100&landmark=true", &list); code != http.StatusOK {
+				t.Fatalf("landmark=true: want 200, got %d", code)
+			}
+			if list.Pagination.Total == 0 {
+				t.Fatal("no landmarks came back, so the count below proves nothing")
+			}
+			if db.Landmark.Count != int64(list.Pagination.Total) {
+				t.Errorf("%s: /health says %d landmarks, ?landmark=true returns %d — the release "+
+					"check would be asserting against a number the service does not filter by",
+					lang, db.Landmark.Count, list.Pagination.Total)
+			}
+		})
+	}
+}
+
+// TestServiceBootsWithoutALandmarkColumn is the rollback test, and it is the
+// whole reason the presence probe exists.
+//
+// `landmark` arrived on 2026-08-12. Every release before that has no such
+// column — which, at the time this was written, was every artifact on the box —
+// and those files are rollback targets: publish-db.sh's rollback() re-points
+// `current` at the previous release and restarts. The lesson was already paid
+// for once by `category`, whose absence made this binary refuse to start and
+// turned a rollback into an outage.
+//
+// Measured before this test was written, against a copy of the real RU artifact
+// with the column dropped: GORM's own statements survive untouched — they SELECT
+// * and leave the struct field at its zero value — while `WHERE landmark = ?`
+// fails with `no such column: landmark`. So the parts that need guarding are
+// exactly the two that name the column by hand, and this asserts both.
+func TestServiceBootsWithoutALandmarkColumn(t *testing.T) {
+	dir := stageArtifact(t, func(db *sql.DB) error {
+		_, err := db.Exec(`ALTER TABLE events DROP COLUMN landmark`)
+		return err
+	})
+
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("the service refused to start against an artifact predating the landmark "+
+			"column. That artifact is a rollback target, and everything except ?landmark= "+
+			"works perfectly well on it: %v\n--- log ---\n%s", startErr, serviceLog)
+	}
+	if !strings.Contains(serviceLog, "no landmark column") {
+		t.Errorf("the service degraded silently; nothing in its log says the artifact has no "+
+			"landmark column:\n%s", serviceLog)
+	}
+
+	// Everything not keyed on the column still works.
+	var list eventList
+	if code := getFrom(t, base, "/api/events?lang=ru&limit=100", &list); code != http.StatusOK {
+		t.Fatalf("/api/events: want 200, got %d", code)
+	}
+	if list.Pagination.Total != 5 {
+		t.Errorf("/api/events total: want 5, got %d", list.Pagination.Total)
+	}
+	// The field still renders, as false, on rows that carried it before the
+	// rollback. That is the documented contract on such an artifact and the
+	// reason the field is a bool rather than a pointer — so pin it, because the
+	// alternative shapes (a missing key, or null) are what a *bool would give.
+	for _, e := range list.Events {
+		if e.Landmark {
+			t.Errorf("event %d reports landmark true on an artifact with no landmark column",
+				e.ID)
+		}
+	}
+
+	// Search especially. It is the one handler that enumerates its columns by
+	// hand instead of letting GORM derive them, so it is the one that would name
+	// e.landmark into a table that has none — and `category` proved that failure
+	// answers 500 to every query while the rest of the service is fine. Booting
+	// and then failing every search is not a rollback that worked.
+	var found eventList
+	if code := getFrom(t, base, "/api/search?lang=ru&q=satoshi&limit=100", &found); code != http.StatusOK {
+		t.Errorf("/api/search: want 200, got %d — the hand-written SELECT in "+
+			"ftsSearchHandler still names a column this artifact does not have", code)
+	}
+	if len(found.Events) == 0 {
+		t.Error("/api/search returned nothing for a term the fixture carries; a 200 with an " +
+			"empty list is the failure this would otherwise hide")
+	}
+
+	// The filter cannot be answered, so it must be refused. 200 would be an empty
+	// list indistinguishable from an artifact with no landmarks, and 500 would be
+	// a server error for a question the server can answer — which is exactly what
+	// an unguarded `WHERE landmark = ?` produces here.
+	for _, sent := range []string{"true", "false"} {
+		var errBody struct {
+			Error string `json:"error"`
+		}
+		code := getFrom(t, base, "/api/events?lang=ru&landmark="+sent, &errBody)
+		if code != http.StatusBadRequest {
+			t.Errorf("?landmark=%s against an artifact with no landmark column: want 400, got %d",
+				sent, code)
+		}
+		if !strings.Contains(errBody.Error, "predates") {
+			t.Errorf("?landmark=%s: the rejection does not explain that the artifact predates "+
+				"the column: %q", sent, errBody.Error)
+		}
+	}
+
+	// /health must say the column is absent. Serving this artifact is a correct
+	// outcome — it is what a rollback looks like — and the release check treats
+	// absent and empty differently.
+	var health healthDoc
+	fetchJSON(t, base+"/health", &health)
+	if health.Status != "ok" {
+		t.Errorf("status: want ok, got %q — a rollback target is not a degraded service",
+			health.Status)
+	}
+	for lang, db := range health.Databases {
+		if db.Landmark.Present {
+			t.Errorf("%s: /health claims a landmark column on an artifact that has none", lang)
+		}
+		if db.Landmark.Count != 0 {
+			t.Errorf("%s: /health reports %d landmarks with no column to hold them",
+				lang, db.Landmark.Count)
+		}
+	}
+}
+
+// TestNoLandmarksIsReportedNotFatal covers the artifact that has the column and
+// carries the flag on no row.
+//
+// Unlike an empty category vocabulary, this breaks no upstream invariant:
+// validate.py invariant 14 pins every value to 0 or 1 and deliberately sets no
+// target fraction, because the flag is an editorial judgement. So it is legal
+// data — and it would still empty the one UI control the column exists for, with
+// nothing upstream to notice. The service must serve it, say so, and report it
+// where a release can see it.
+//
+// Note what is *not* asserted: ?landmark=true is a 200 with an empty list here,
+// not a 400. The vocabulary case rejects because no value could ever match; this
+// one has a perfectly answerable question with a genuinely empty answer, and
+// refusing it would be the API disagreeing with its own data.
+func TestNoLandmarksIsReportedNotFatal(t *testing.T) {
+	dir := stageArtifact(t, func(db *sql.DB) error {
+		_, err := db.Exec(`UPDATE events SET landmark = 0`)
+		return err
+	})
+
+	base, serviceLog, startErr := bootService(t, dir)
+	if startErr != nil {
+		t.Fatalf("the service refused to start against an artifact carrying no landmarks, "+
+			"which is legal data: %v\n--- log ---\n%s", startErr, serviceLog)
+	}
+	// Distinguishes this from the missing-column path, which also answers no
+	// landmarks — without it this test would pass for the wrong reason.
+	if !strings.Contains(serviceLog, "no landmarks") {
+		t.Errorf("the service degraded silently; nothing in its log says the column carries "+
+			"the flag on no row:\n%s", serviceLog)
+	}
+
+	var list eventList
+	if code := getFrom(t, base, "/api/events?lang=ru&limit=100&landmark=true", &list); code != http.StatusOK {
+		t.Fatalf("?landmark=true: want 200, got %d — the column is present and the question is "+
+			"answerable, so an empty answer is the honest one", code)
+	}
+	if list.Pagination.Total != 0 {
+		t.Errorf("?landmark=true: want 0, got %d", list.Pagination.Total)
+	}
+
+	var health healthDoc
+	fetchJSON(t, base+"/health", &health)
+	if health.Status != "ok" {
+		t.Errorf("status: want ok — no landmarks is not an index problem, got %q", health.Status)
+	}
+	for lang, db := range health.Databases {
+		if !db.Landmark.Present {
+			t.Errorf("%s: /health says the column is absent; it is present and unset, which is "+
+				"a different state with a different fix", lang)
+		}
+		if db.Landmark.Count != 0 {
+			t.Errorf("%s: /health reports %d landmarks on an artifact where every row is 0",
+				lang, db.Landmark.Count)
+		}
+	}
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -154,6 +154,17 @@ func seedArtifact(path, lang string) error {
 	}
 	defer db.Close()
 
+	// `landmark INTEGER NOT NULL DEFAULT 0` is exactly how canonical declares
+	// it, because the declared type is what the driver hands back and a nullable
+	// column would let a NULL reach a Go bool — proving nothing about the shape
+	// the service actually meets.
+	//
+	// That annotation is here rather than as a `--` comment inside the statement
+	// below, and that is not style. SQLite stores the CREATE TABLE text verbatim
+	// in sqlite_master and re-parses it during ALTER TABLE ... DROP COLUMN,
+	// which truncates at the comment: the rollback tests that drop `category`
+	// and `landmark` then fail with `error in table events after drop column:
+	// incomplete input`. Measured — it is how this comment came to be out here.
 	schema := []string{
 		`CREATE TABLE events (
 			id INTEGER PRIMARY KEY,
@@ -166,7 +177,8 @@ func seedArtifact(path, lang string) error {
 			created_at datetime,
 			updated_at datetime,
 			url_path TEXT,
-			category TEXT
+			category TEXT,
+			landmark INTEGER NOT NULL DEFAULT 0
 		)`,
 		`CREATE INDEX idx_events_date ON events(date)`,
 		`CREATE UNIQUE INDEX idx_events_url_path ON events(url_path)`,
@@ -195,9 +207,9 @@ func seedArtifact(path, lang string) error {
 
 	for _, e := range fixtureRows(lang) {
 		if _, err := db.Exec(
-			`INSERT INTO events (id, date, title, description, media, tags, "references", created_at, updated_at, url_path, category)
-			 VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
-			e.ID, e.Date, e.Title, e.Description, e.Media, e.Tags, e.References, e.CreatedAt, e.UpdatedAt, e.URLPath, e.Category,
+			`INSERT INTO events (id, date, title, description, media, tags, "references", created_at, updated_at, url_path, category, landmark)
+			 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+			e.ID, e.Date, e.Title, e.Description, e.Media, e.Tags, e.References, e.CreatedAt, e.UpdatedAt, e.URLPath, e.Category, e.Landmark,
 		); err != nil {
 			return err
 		}
@@ -220,24 +232,47 @@ type fixtureRow struct {
 	Tags, URLPath        string
 	// Mandatory in canonical by validator invariant 13 — one value per row from
 	// a closed set — so every fixture row carries one. The set is owned by the
-	// data and grows (it gained `security` on 2026-08-10), so nothing here
-	// asserts its size; TestFixtureSchemaMatchesCanonical compares columns, not
-	// values, for exactly that reason.
+	// data and changes in both directions (it gained `security` on 2026-08-10
+	// and was rewritten from fifteen values to eight on 2026-08-12), so nothing
+	// here asserts its size; TestFixtureSchemaMatchesCanonical compares columns,
+	// not values, for exactly that reason.
 	//
-	// Every value below is a real member of that set except one, event 5's, and
-	// that exception is the whole point: see syntheticCategory.
+	// These values are deliberately NOT resynchronised with canonical's current
+	// eight. `mustread` and `bitcoin` below were real members until 2026-08-12
+	// and are not any more, which changes nothing these tests prove: the fixture
+	// is self-contained, the service holds no list to disagree with it, and the
+	// schema guard compares columns rather than values. Retargeting them would
+	// churn every assertion in category_test.go to prove the same properties.
+	// See syntheticCategory, whose argument this does slightly change.
 	Category string
+	// Landmark is canonical's `landmark`, added 2026-08-12: a boolean, orthogonal
+	// to Category, and NOT NULL DEFAULT 0 upstream so it has exactly one spelling
+	// for false.
+	//
+	// Event 2 must keep this true. It is the only row `q=bitcoin` matches in the
+	// RU fixture, so it is the only row through which /api/search can prove it
+	// fetched the column at all — see TestEventStructCoversEveryColumn, which a
+	// false cannot satisfy because false is also what an unfetched column
+	// marshals to.
+	Landmark bool
 }
 
 // syntheticCategory is deliberately NOT a member of canonical's vocabulary, and
 // it is the only assertion in this suite that can tell the boot-derived
 // vocabulary apart from a hardcoded list.
 //
-// Every other fixture category — holiday, mustread, archives, bitcoin — is a
-// real canonical value, so a compiled-in list would contain all of them and
-// accept all of them. Replacing loadCategories with such a list was measured
-// against this suite before this row existed: `go vet` clean, every test green.
-// The design the filter exists for was pinned by nothing.
+// When this row was written, every other fixture category — holiday, mustread,
+// archives, bitcoin — was a real canonical value, so a compiled-in list would
+// have contained all of them and accepted all of them. Replacing loadCategories
+// with such a list was measured against this suite before this row existed: `go
+// vet` clean, every test green. The design the filter exists for was pinned by
+// nothing.
+//
+// Canonical's 2026-08-12 rewrite left only holiday and archives from that set —
+// mustread and bitcoin are no longer members either. That weakens the sentence
+// above without weakening the row: this value was never a member and never will
+// be, whichever direction the vocabulary moves next, so it remains the one
+// assertion here that a hardcoded list cannot satisfy by accident.
 //
 // So one row carries a value no hardcoded list could ever hold. The filter
 // accepts it only if the vocabulary really was read out of the artifact at boot,
@@ -255,6 +290,11 @@ func strptr(s string) *string { return &s }
 // fixtureRows deliberately includes the awkward cases: a pre-epoch date, absent
 // media and references as NULL, absent timestamps, and an event that lists the
 // same tag twice.
+//
+// Landmark is true on events 1 and 2 and false on the rest — RU 2 of 5, EN 2 of
+// 4. Both states have to exist for ?landmark= to be provably a filter rather
+// than a pass-through, and the two languages differ so that a handler reading
+// the wrong artifact cannot go unnoticed.
 func fixtureRows(lang string) []fixtureRow {
 	rows := []fixtureRow{
 		{
@@ -273,6 +313,10 @@ func fixtureRows(lang string) []fixtureRow {
 			// fixture whose category always matched tags[0] would let the very
 			// inference canonical retired keep passing its tests.
 			Category: "holiday",
+			// One of two landmarks in this fixture. Two rather than one so that
+			// ?landmark=true returning the right set cannot be satisfied by a
+			// handler that happens to return a single row for another reason.
+			Landmark: true,
 		},
 		{
 			ID: 2, Date: "2008-11-01",
@@ -283,6 +327,12 @@ func fixtureRows(lang string) []fixtureRow {
 			CreatedAt:   strptr("2026-08-08 09:59:56"), UpdatedAt: strptr("2026-08-08 09:59:56"),
 			Tags: `["satoshi", "mustread"]`, URLPath: "/2008-11-01/bitcoin-whitepaper-published/",
 			Category: "mustread",
+			// Load-bearing, and not interchangeable with the other landmark: this
+			// is the only row `q=bitcoin` matches in either fixture, so it is the
+			// only one through which TestEventStructCoversEveryColumn can prove
+			// /api/search fetched the landmark column. Set this to false and that
+			// test goes green against a search handler that never selects it.
+			Landmark: true,
 		},
 		{
 			ID: 3, Date: "2013-08-09",
@@ -480,8 +530,14 @@ type event struct {
 	References  *string `json:"references"`
 	URLPath     string  `json:"url_path"`
 	Category    string  `json:"category"`
-	CreatedAt   *string `json:"created_at"`
-	UpdatedAt   *string `json:"updated_at"`
+	// Not a pointer, deliberately, mirroring the service: the contract says
+	// landmark is always a bool, never null. Decoding into a plain bool is also
+	// what would catch the service starting to emit null — encoding/json would
+	// leave it false and the assertions that expect true would fail, which is
+	// the direction that gets noticed.
+	Landmark  bool    `json:"landmark"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
 }
 
 type eventList struct {

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -170,11 +170,25 @@ func eventRow(t *testing.T, path, id string) map[string]any {
 	return out
 }
 
-// isNullOrEmpty reports whether a JSON value carries nothing — the two shapes a
-// dropped column takes, depending on whether its Go field is a pointer.
+// isNullOrEmpty reports whether a JSON value carries nothing — the shapes a
+// dropped column takes, which depend on the Go field's type.
+//
+// `false` and `0` are in the list, and they are the reason this comment is
+// longer than the function. A Go bool field the SELECT never fetched marshals
+// to `false`, exactly like one fetched from a row storing 0; an int field
+// marshals to `0` the same way. Without them, `landmark` would have been
+// "proven" by any row storing 0 — which is 179 of 581 RU rows — so the whole
+// guard would have passed against a search handler that never selected the
+// column, which is precisely the bug it was written for after `category`
+// shipped that way. Only a `true` proves a boolean column was really fetched.
+//
+// The cost is that a column whose every row is false or 0 can never be proven,
+// and the test then reports it as emitted-but-never-valued. That is the right
+// direction to fail in: the fixture is ours to fix, and a fixture with no true
+// row genuinely cannot distinguish the two cases.
 func isNullOrEmpty(raw json.RawMessage) bool {
 	s := strings.TrimSpace(string(raw))
-	return s == "" || s == "null" || s == `""`
+	return s == "" || s == "null" || s == `""` || s == "false" || s == "0"
 }
 
 // TestFixtureSchemaMatchesCanonical closes the loop that TestEventStructCovers-


### PR DESCRIPTION
Canonical's step40 taxonomy migration (applied 2026-08-12) added a `landmark` column and
rewrote the `category` vocabulary from fifteen values to eight. The schema guard in
`publish-db.sh` was correctly refusing to publish the new artifacts. This wires `landmark`
end to end so it can.

## The column

`landmark INTEGER NOT NULL DEFAULT 0` — a boolean, orthogonal to `category`, driving one UI
control (the «Только главное» switch). 402 of 581 RU rows and 394 of 565 EN rows carry it.

Modelled as a plain `bool`, JSON `landmark`. The name is forced by
`TestEventStructCoversEveryColumn`, which indexes responses by the artifact's own column name.
`bool` rather than `*bool` because canonical chose `NOT NULL` specifically so that "not a
landmark" has exactly one spelling — a pointer would put the second spelling back into the
JSON for a state no published artifact holds. `Category` sets the same precedent, rendering
`""` on artifacts that predate it.

## Rollback tolerance

Every artifact currently on the box predates `landmark`, so this had to work against one.
Measured against a copy of the real RU artifact with the column dropped:

| | with column | column dropped |
|---|---|---|
| GORM `Find`/`First` | `true` | `false`, no error |
| `WHERE landmark = ?` | 402 | `no such column: landmark` |

GORM's own statements adapt for free — they `SELECT *` and leave the field at its zero value.
The two sites that name the column by hand do not, and both are now presence-guarded through a
shared `hasColumn()` helper factored out of `loadCategories`:

- `ftsSearchHandler`'s hand-written SELECT, which would otherwise 500 on every search — the
  exact failure `category` caused;
- the new `?landmark=` filter, which answers 400 explaining that the artifact predates the
  column rather than a misleading empty list.

Against that dropped-column artifact the service boots, logs why, serves 244 search hits for
`биткоин` and 99 for `?category=tech`, and reports `landmark.present: false` on `/health`.
Covered by `TestServiceBootsWithoutALandmarkColumn`, modelled on the `category` equivalent.

## `?landmark=` on /api/events

Added now rather than later because doing nothing was not neutral: once the response emits a
`landmark` field, a client sends `?landmark=true`, and `/api/events` would have accepted it
silently and answered 200 with everything — the pass-through `filterParamRejected` exists to
eliminate. Accepts what `strconv.ParseBool` does; ANDs with `?category=` and the date filters;
refused on `/api/search` and `/api/events/tags/:tag` from the start, so it never has a window
of being silently ignored there.

## A hole in the schema guard

`TestEventStructCoversEveryColumn` could not have caught a dropped `landmark`. It proves a
column was fetched by checking the emitted value is not null-or-empty, and a Go `bool` the
SELECT never fetched marshals to `false` — which the old `isNullOrEmpty` did not match. So the
guard would have passed against a search handler that never selected the column: the same bug
it was written for after `category` shipped that way.

Verified by sabotage rather than argument — with `e.landmark` removed from the search SELECT,
the new version fails with the right message and the old version passes green. `isNullOrEmpty`
now also matches `false` and `0`, so only a `true` proves a boolean column was really fetched.
That is why fixture event 2 must keep `landmark: true`: it is the only row `q=bitcoin` matches.

## The category shrink

No code change needed, and confirmed to hold in the shrinking direction, not just the growth
direction the comment argued: `loadCategories` does `SELECT DISTINCT` over live rows, so a
value that leaves the data leaves the vocabulary in the same release. `?category=bitcoin` is
now a 400 naming the eight replacements rather than a silent empty list. Nothing asserted the
count 15 — only stale samples in the docs.

`VOCAB_RU_LAST` / `VOCAB_EN_LAST` are unchanged and left alone: step40 touched none of the
three columns `events_fts` indexes. Re-measured at 244 / 389 against both the current
artifacts and `dbs/superseded/*pre-step40*`.

## Deploy scripts

- `publish-db.sh` verifies the landmark flag alongside the vocabulary. Absent column is a
  failure (bypassable with `--allow-schema-drift`); zero landmarks is a **warning**, because
  validator invariant 14 pins every value to 0 or 1 but deliberately sets no target fraction.
- `publish-api.sh` compares the flag across a binary deploy, guarded so the release that
  introduces the field does not fail on its own new field.
- Both Python verify blocks were extracted and exercised against synthetic `/health` payloads
  covering every branch, including the category cases, to confirm nothing was weakened.

## Order of operations

`publish-api.sh` then `publish-db.sh` — because binary-first is free, not because the other
order breaks anything. The service is built to serve an artifact older than itself, so
binary-first always works. Data-first is not an outage either; the column just reaches no
response until the binary catches up, and nothing consumes this API today except the Telegram
bot, which reads neither column. Worth care only because the schema guard runs from the local
repo and cannot see the box's binary age — `/health` is what reports it.

## Verification

`gofmt` clean, `go vet` clean, full suite green, schema guard green against both real
canonical artifacts. Ran the built binary against read-only copies of the real artifacts:
`?landmark=true` returns 402 / `false` 179 / unfiltered 581, and per-category rates match the
changelog's stated figures (tech 75%, obituary 2%). Canonical checksums verified untouched
throughout.
